### PR TITLE
Fix documentation parameter casing

### DIFF
--- a/doc/apps/facebook.md
+++ b/doc/apps/facebook.md
@@ -12,7 +12,7 @@ final deeplinkX = DeeplinkX();
 await deeplinkX.launchApp(Facebook.open());
 
 // Launch with store fallback if not installed
-await deeplinkX.launchApp(Facebook.open(fallBackToStore: true));
+await deeplinkX.launchApp(Facebook.open(fallbackToStore: true));
 
 // Launch with fallback disabled
 await deeplinkX.launchApp(Facebook.open(), disableFallback: true);
@@ -28,7 +28,7 @@ await deeplinkX.launchAction(Facebook.openProfileById(id: 'profileId')); // Face
 // Action with store fallback if not installed
 await deeplinkX.launchAction(Facebook.openProfileById(
   id: 'profileId', // Facebook numeric ID (e.g. '123456789')
-  fallBackToStore: true,
+  fallbackToStore: true,
 ));
 
 // Action with fallback disabled
@@ -48,7 +48,7 @@ await deeplinkX.launchAction(Facebook.openProfileByUsername(username: 'username'
 // Action with store fallback if not installed
 await deeplinkX.launchAction(Facebook.openProfileByUsername(
   username: 'username', // Facebook username (e.g. 'zuck' for Mark Zuckerberg)
-  fallBackToStore: true,
+  fallbackToStore: true,
 ));
 
 // Action with fallback disabled
@@ -68,7 +68,7 @@ await deeplinkX.launchAction(Facebook.openPage(pageId: 'pageId')); // Facebook p
 // Action with store fallback if not installed
 await deeplinkX.launchAction(Facebook.openPage(
   pageId: 'pageId', // Facebook page ID (e.g. 'facebookapp' for Facebook's official page)
-  fallBackToStore: true,
+  fallbackToStore: true,
 ));
 
 // Action with fallback disabled
@@ -88,7 +88,7 @@ await deeplinkX.launchAction(Facebook.openGroup(groupId: 'groupId')); // Faceboo
 // Action with store fallback if not installed
 await deeplinkX.launchAction(Facebook.openGroup(
   groupId: 'groupId', // Facebook group ID (e.g. '231104380821004' for Flutter Community group)
-  fallBackToStore: true,
+  fallbackToStore: true,
 ));
 
 // Action with fallback disabled
@@ -108,7 +108,7 @@ await deeplinkX.launchAction(Facebook.openEvent(eventId: 'eventId')); // Faceboo
 // Action with store fallback if not installed
 await deeplinkX.launchAction(Facebook.openEvent(
   eventId: 'eventId', // Facebook event ID (e.g. '10155945715431729' for F8 Conference)
-  fallBackToStore: true,
+  fallbackToStore: true,
 ));
 
 // Action with fallback disabled

--- a/doc/apps/instagram.md
+++ b/doc/apps/instagram.md
@@ -12,7 +12,7 @@ final deeplinkX = DeeplinkX();
 await deeplinkX.launchApp(Instagram.open());
 
 // Launch with store fallback if not installed
-await deeplinkX.launchApp(Instagram.open(fallBackToStore: true));
+await deeplinkX.launchApp(Instagram.open(fallbackToStore: true));
 
 // Launch with fallback disabled
 await deeplinkX.launchApp(Instagram.open(), disableFallback: true);
@@ -26,7 +26,7 @@ final deeplinkX = DeeplinkX();
 await deeplinkX.launchAction(Instagram.openProfile('username'));
 
 // Action with store fallback if not installed
-await deeplinkX.launchAction(Instagram.openProfile('username', fallBackToStore: true));
+await deeplinkX.launchAction(Instagram.openProfile('username', fallbackToStore: true));
 
 // Action with fallback disabled
 await deeplinkX.launchAction(Instagram.openProfile('username'), disableFallback: true);
@@ -106,18 +106,18 @@ When the Instagram app is not installed, DeeplinkX can redirect users to downloa
 - iOS App Store
 - Google Play Store
 
-To enable fallback to app stores, use the `fallBackToStore` parameter:
+To enable fallback to app stores, use the `fallbackToStore` parameter:
 
 ```dart
 final deeplinkX = DeeplinkX();
-await deeplinkX.launchApp(Instagram.open(fallBackToStore: true));
+await deeplinkX.launchApp(Instagram.open(fallbackToStore: true));
 ```
 
 ## Fallback Behavior
 DeeplinkX follows this sequence when handling Instagram deeplinks:
 
 1. First, it attempts to launch the Instagram app if it's installed on the device.
-2. If the Instagram app is not installed and `fallBackToStore` is set to `true`, it will redirect to the appropriate app store based on the user's platform (iOS App Store or Google Play Store).
+2. If the Instagram app is not installed and `fallbackToStore` is set to `true`, it will redirect to the appropriate app store based on the user's platform (iOS App Store or Google Play Store).
 3. If no supported store is available for the current platform or the store app cannot be launched, it will fall back to opening the Instagram web interface in the default browser.
 4. You can disable all fallbacks by setting `disableFallback: true` in the launch methods.
 

--- a/doc/apps/linkedin.md
+++ b/doc/apps/linkedin.md
@@ -12,7 +12,7 @@ final deeplinkX = DeeplinkX();
 await deeplinkX.launchApp(LinkedIn.open());
 
 // Launch with store fallback if not installed
-await deeplinkX.launchApp(LinkedIn.open(fallBackToStore: true));
+await deeplinkX.launchApp(LinkedIn.open(fallbackToStore: true));
 
 // Launch with fallback disabled
 await deeplinkX.launchApp(LinkedIn.open(), disableFallback: true);
@@ -31,7 +31,7 @@ await deeplinkX.launchAction(LinkedIn.openProfile(
 await deeplinkX.launchAction(
   LinkedIn.openProfile(
     profileId: 'johndoe',
-    fallBackToStore: true,
+    fallbackToStore: true,
   ),
 );
 
@@ -57,7 +57,7 @@ await deeplinkX.launchAction(LinkedIn.openCompany(
 await deeplinkX.launchAction(
   LinkedIn.openCompany(
     companyId: 'company-id',
-    fallBackToStore: true,
+    fallbackToStore: true,
   ),
 );
 
@@ -128,11 +128,11 @@ When the LinkedIn app is not installed, DeeplinkX can redirect users to download
 - Google Play Store
 - Microsoft Store
 
-To enable fallback to app stores, use the `fallBackToStore` parameter:
+To enable fallback to app stores, use the `fallbackToStore` parameter:
 
 ```dart
 final deeplinkX = DeeplinkX();
-await deeplinkX.launchApp(LinkedIn.open(fallBackToStore: true));
+await deeplinkX.launchApp(LinkedIn.open(fallbackToStore: true));
 ```
 
 ## Fallback Behavior

--- a/doc/apps/pinterest.md
+++ b/doc/apps/pinterest.md
@@ -15,7 +15,7 @@ await deeplinkX.launchApp(Pinterest.open());
 With fallback to app store:
 
 ```dart
-await deeplinkX.launchApp(Pinterest.open(fallBackToStore: true));
+await deeplinkX.launchApp(Pinterest.open(fallbackToStore: true));
 ```
 
 Without fallback:
@@ -183,7 +183,7 @@ When Pinterest is not installed, DeeplinkX automatically falls back to:
 When the Pinterest app is not installed, DeeplinkX can redirect users to download Pinterest from the following app stores:
 
 ```dart
-await deeplinkX.launchApp(Pinterest.open(fallBackToStore: true));
+await deeplinkX.launchApp(Pinterest.open(fallbackToStore: true));
 ```
 
 ## Fallback Behavior
@@ -191,5 +191,5 @@ await deeplinkX.launchApp(Pinterest.open(fallBackToStore: true));
 DeeplinkX follows this sequence when handling Pinterest deeplinks:
 
 1. First, it attempts to launch the Pinterest app if it's installed on the device.
-2. If the Pinterest app is not installed and `fallBackToStore` is set to `true`, it will redirect to the appropriate app store based on the user's platform (iOS App Store or Google Play Store).
+2. If the Pinterest app is not installed and `fallbackToStore` is set to `true`, it will redirect to the appropriate app store based on the user's platform (iOS App Store or Google Play Store).
 3. If no supported store is available for the current platform or the store app cannot be launched, it will fall back to opening the Pinterest web interface in the default browser. 

--- a/doc/apps/telegram.md
+++ b/doc/apps/telegram.md
@@ -12,7 +12,7 @@ final deeplinkX = DeeplinkX();
 await deeplinkX.launchApp(Telegram.open());
 
 // Launch with store fallback if not installed
-await deeplinkX.launchApp(Telegram.open(fallBackToStore: true));
+await deeplinkX.launchApp(Telegram.open(fallbackToStore: true));
 
 // Launch with fallback disabled
 await deeplinkX.launchApp(Telegram.open(), disableFallback: true);
@@ -26,7 +26,7 @@ final deeplinkX = DeeplinkX();
 await deeplinkX.launchAction(Telegram.openProfile('username'));
 
 // Action with store fallback if not installed
-await deeplinkX.launchAction(Telegram.openProfile('username', fallBackToStore: true));
+await deeplinkX.launchAction(Telegram.openProfile('username', fallbackToStore: true));
 
 // Action with fallback disabled
 await deeplinkX.launchAction(Telegram.openProfile('username'), disableFallback: true);
@@ -40,7 +40,7 @@ final deeplinkX = DeeplinkX();
 await deeplinkX.launchAction(Telegram.openProfileByPhone('1234567890'));
 
 // Action with store fallback if not installed
-await deeplinkX.launchAction(Telegram.openProfileByPhone('1234567890', fallBackToStore: true));
+await deeplinkX.launchAction(Telegram.openProfileByPhone('1234567890', fallbackToStore: true));
 
 // Action with fallback disabled
 await deeplinkX.launchAction(Telegram.openProfileByPhone('1234567890'), disableFallback: true);
@@ -61,7 +61,7 @@ await deeplinkX.launchAction(
   Telegram.sendMessage(
     username: 'username',
     message: 'Hello!',
-    fallBackToStore: true,
+    fallbackToStore: true,
   ),
 );
 
@@ -194,18 +194,18 @@ When the Telegram app is not installed, DeeplinkX can redirect users to download
 - Mac App Store
 - Microsoft Store
 
-To enable fallback to app stores, use the `fallBackToStore` parameter:
+To enable fallback to app stores, use the `fallbackToStore` parameter:
 
 ```dart
 final deeplinkX = DeeplinkX();
-await deeplinkX.launchApp(Telegram.open(fallBackToStore: true));
+await deeplinkX.launchApp(Telegram.open(fallbackToStore: true));
 ```
 
 ## Fallback Behavior
 DeeplinkX follows this sequence when handling Telegram deeplinks:
 
 1. First, it attempts to launch the Telegram app if it's installed on the device.
-2. If the Telegram app is not installed and `fallBackToStore` is set to `true`, it will redirect to the appropriate app store based on the user's platform (iOS App Store, Google Play Store, Mac App Store, or Microsoft Store).
+2. If the Telegram app is not installed and `fallbackToStore` is set to `true`, it will redirect to the appropriate app store based on the user's platform (iOS App Store, Google Play Store, Mac App Store, or Microsoft Store).
 3. If no supported store is available for the current platform or the store app cannot be launched, it will fall back to opening the Telegram web interface in the default browser.
 4. You can disable all fallbacks by setting `disableFallback: true` in the launch methods.
 

--- a/doc/apps/tiktok.md
+++ b/doc/apps/tiktok.md
@@ -12,7 +12,7 @@ final deeplinkX = DeeplinkX();
 await deeplinkX.launchApp(TikTok.open());
 
 // Launch with store fallback if not installed
-await deeplinkX.launchApp(TikTok.open(fallBackToStore: true));
+await deeplinkX.launchApp(TikTok.open(fallbackToStore: true));
 
 // Launch with fallback disabled
 await deeplinkX.launchApp(TikTok.open(), disableFallback: true);
@@ -28,7 +28,7 @@ await deeplinkX.launchAction(TikTok.openProfile(username: 'tiktok')); // TikTok 
 // Action with store fallback if not installed
 await deeplinkX.launchAction(TikTok.openProfile(
   username: 'tiktok', // TikTok username
-  fallBackToStore: true,
+  fallbackToStore: true,
 ));
 
 // Action with fallback disabled
@@ -48,7 +48,7 @@ await deeplinkX.launchAction(TikTok.openVideo(videoId: '7123456789012345678')); 
 // Action with store fallback if not installed
 await deeplinkX.launchAction(TikTok.openVideo(
   videoId: '7123456789012345678', // TikTok video ID
-  fallBackToStore: true,
+  fallbackToStore: true,
 ));
 
 // Action with fallback disabled
@@ -68,7 +68,7 @@ await deeplinkX.launchAction(TikTok.openTag(tagName: 'flutter')); // TikTok tag 
 // Action with store fallback if not installed
 await deeplinkX.launchAction(TikTok.openTag(
   tagName: 'flutter', // TikTok tag name
-  fallBackToStore: true,
+  fallbackToStore: true,
 ));
 
 // Action with fallback disabled
@@ -165,18 +165,18 @@ When the TikTok app is not installed, DeeplinkX can redirect users to download T
 - iOS App Store
 - Google Play Store
 
-To enable fallback to app stores, use the `fallBackToStore` parameter:
+To enable fallback to app stores, use the `fallbackToStore` parameter:
 
 ```dart
 final deeplinkX = DeeplinkX();
-await deeplinkX.launchApp(TikTok.open(fallBackToStore: true));
+await deeplinkX.launchApp(TikTok.open(fallbackToStore: true));
 ```
 
 ## Fallback Behavior
 DeeplinkX follows this sequence when handling TikTok deeplinks:
 
 1. First, it attempts to launch the TikTok app if it's installed on the device.
-2. If the TikTok app is not installed and `fallBackToStore` is set to `true`, it will redirect to the appropriate app store based on the user's platform (iOS App Store or Google Play Store).
+2. If the TikTok app is not installed and `fallbackToStore` is set to `true`, it will redirect to the appropriate app store based on the user's platform (iOS App Store or Google Play Store).
 3. If no supported store is available for the current platform or the store app cannot be launched, it will fall back to opening the TikTok web interface in the default browser.
 4. You can disable all fallbacks by setting `disableFallback: true` in the launch methods.
 

--- a/doc/apps/twitter.md
+++ b/doc/apps/twitter.md
@@ -12,7 +12,7 @@ final deeplinkX = DeeplinkX();
 await deeplinkX.launchApp(Twitter.open());
 
 // Launch with store fallback if not installed
-await deeplinkX.launchApp(Twitter.open(fallBackToStore: true));
+await deeplinkX.launchApp(Twitter.open(fallbackToStore: true));
 
 // Launch with fallback disabled
 await deeplinkX.launchApp(Twitter.open(), disableFallback: true);
@@ -28,7 +28,7 @@ await deeplinkX.launchAction(Twitter.openProfile(username: 'twitter')); // Twitt
 // Action with store fallback if not installed
 await deeplinkX.launchAction(Twitter.openProfile(
   username: 'twitter', // Twitter username
-  fallBackToStore: true,
+  fallbackToStore: true,
 ));
 
 // Action with fallback disabled
@@ -48,7 +48,7 @@ await deeplinkX.launchAction(Twitter.openTweet(tweetId: '1234567890')); // Twitt
 // Action with store fallback if not installed
 await deeplinkX.launchAction(Twitter.openTweet(
   tweetId: '1234567890', // Twitter tweet ID
-  fallBackToStore: true,
+  fallbackToStore: true,
 ));
 
 // Action with fallback disabled
@@ -68,7 +68,7 @@ await deeplinkX.launchAction(Twitter.search(query: 'flutter')); // Search query
 // Action with store fallback if not installed
 await deeplinkX.launchAction(Twitter.search(
   query: 'flutter', // Search query
-  fallBackToStore: true,
+  fallbackToStore: true,
 ));
 
 // Action with fallback disabled
@@ -160,18 +160,18 @@ When the Twitter app is not installed, DeeplinkX can redirect users to download 
 - iOS App Store
 - Google Play Store
 
-To enable fallback to app stores, use the `fallBackToStore` parameter:
+To enable fallback to app stores, use the `fallbackToStore` parameter:
 
 ```dart
 final deeplinkX = DeeplinkX();
-await deeplinkX.launchApp(Twitter.open(fallBackToStore: true));
+await deeplinkX.launchApp(Twitter.open(fallbackToStore: true));
 ```
 
 ## Fallback Behavior
 DeeplinkX follows this sequence when handling Twitter deeplinks:
 
 1. First, it attempts to launch the Twitter app if it's installed on the device.
-2. If the Twitter app is not installed and `fallBackToStore` is set to `true`, it will redirect to the appropriate app store based on the user's platform (iOS App Store or Google Play Store).
+2. If the Twitter app is not installed and `fallbackToStore` is set to `true`, it will redirect to the appropriate app store based on the user's platform (iOS App Store or Google Play Store).
 3. If no supported store is available for the current platform or the store app cannot be launched, it will fall back to opening the Twitter web interface in the default browser.
 4. You can disable all fallbacks by setting `disableFallback: true` in the launch methods.
 

--- a/doc/apps/whatsapp.md
+++ b/doc/apps/whatsapp.md
@@ -13,7 +13,7 @@ final deeplinkX = DeeplinkX();
 await deeplinkX.launchApp(WhatsApp.open());
 
 // Launch with store fallback if not installed
-await deeplinkX.launchApp(WhatsApp.open(fallBackToStore: true));
+await deeplinkX.launchApp(WhatsApp.open(fallbackToStore: true));
 
 // Launch with fallback disabled
 await deeplinkX.launchApp(WhatsApp.open(), disableFallback: true);
@@ -34,7 +34,7 @@ await deeplinkX.launchAction(
   WhatsApp.chat(
     phoneNumber: '1234567890',
     message: 'Hello!', // Optional
-    fallBackToStore: true,
+    fallbackToStore: true,
   ),
 );
 
@@ -61,7 +61,7 @@ await deeplinkX.launchAction(WhatsApp.share(
 await deeplinkX.launchAction(
   WhatsApp.share(
     text: 'Check out this cool Flutter package: https://pub.dev/packages/deeplink_x',
-    fallBackToStore: true,
+    fallbackToStore: true,
   ),
 );
 
@@ -144,18 +144,18 @@ When the WhatsApp app is not installed, DeeplinkX can redirect users to download
 - Microsoft Store
 - Mac App Store
 
-To enable fallback to app stores, use the `fallBackToStore` parameter:
+To enable fallback to app stores, use the `fallbackToStore` parameter:
 
 ```dart
 final deeplinkX = DeeplinkX();
-await deeplinkX.launchApp(WhatsApp.open(fallBackToStore: true));
+await deeplinkX.launchApp(WhatsApp.open(fallbackToStore: true));
 ```
 
 ## Fallback Behavior
 DeeplinkX follows this sequence when handling WhatsApp deeplinks:
 
 1. First, it attempts to launch the WhatsApp app if it's installed on the device using the `whatsapp://` URL scheme.
-2. If the WhatsApp app is not installed and `fallBackToStore` is set to `true`, it will redirect to the appropriate app store based on the user's platform (iOS App Store or Google Play Store).
+2. If the WhatsApp app is not installed and `fallbackToStore` is set to `true`, it will redirect to the appropriate app store based on the user's platform (iOS App Store or Google Play Store).
 3. If no supported store is available for the current platform or the store app cannot be launched, it will fall back to opening the WhatsApp web interface in the default browser.
 4. You can disable all fallbacks by setting `disableFallback: true` in the launch methods.
 

--- a/doc/apps/youtube.md
+++ b/doc/apps/youtube.md
@@ -12,7 +12,7 @@ final deeplinkX = DeeplinkX();
 await deeplinkX.launchApp(YouTube.open());
 
 // Launch with store fallback if not installed
-await deeplinkX.launchApp(YouTube.open(fallBackToStore: true));
+await deeplinkX.launchApp(YouTube.open(fallbackToStore: true));
 
 // Launch with fallback disabled
 await deeplinkX.launchApp(YouTube.open(), disableFallback: true);
@@ -28,7 +28,7 @@ await deeplinkX.launchAction(YouTube.openVideo(videoId: 'dQw4w9WgXcQ')); // YouT
 // Action with store fallback if not installed
 await deeplinkX.launchAction(YouTube.openVideo(
   videoId: 'dQw4w9WgXcQ', // YouTube video ID
-  fallBackToStore: true,
+  fallbackToStore: true,
 ));
 
 // Action with fallback disabled
@@ -48,7 +48,7 @@ await deeplinkX.launchAction(YouTube.openChannel(channelId: 'UCq-Fj5jknLsUf-MWSy
 // Action with store fallback if not installed
 await deeplinkX.launchAction(YouTube.openChannel(
   channelId: 'UCq-Fj5jknLsUf-MWSy4_brA', // YouTube channel ID
-  fallBackToStore: true,
+  fallbackToStore: true,
 ));
 
 // Action with fallback disabled
@@ -68,7 +68,7 @@ await deeplinkX.launchAction(YouTube.openPlaylist(playlistId: 'PLFgquLnL59alCl_2
 // Action with store fallback if not installed
 await deeplinkX.launchAction(YouTube.openPlaylist(
   playlistId: 'PLFgquLnL59alCl_2TQvOiD5Vgm1hCaGSI', // YouTube playlist ID
-  fallBackToStore: true,
+  fallbackToStore: true,
 ));
 
 // Action with fallback disabled
@@ -88,7 +88,7 @@ await deeplinkX.launchAction(YouTube.search(query: 'flutter tutorial')); // Sear
 // Action with store fallback if not installed
 await deeplinkX.launchAction(YouTube.search(
   query: 'flutter tutorial', // Search query
-  fallBackToStore: true,
+  fallbackToStore: true,
 ));
 
 // Action with fallback disabled


### PR DESCRIPTION
## Summary
- search & replace `fallBackToStore` with `fallbackToStore` across docs
- keep code snippets consistent with the API

## Testing
- `dart pub get`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6841795de1588333b4181d2e8cbca8fd