### PR TITLE
Fix parameter typo in PlatformUtil

### DIFF
--- a/lib/src/utils/platform_util.dart
+++ b/lib/src/utils/platform_util.dart
@@ -10,7 +10,7 @@ class PlatformUtil {
   ///
   /// Since this class only contains static methods and has no instance state,
   /// it can be instantiated as a const object.
-  PlatformUtil({final String? platfromName}) : _platformName = platfromName ?? defaultTargetPlatform.name;
+  PlatformUtil({final String? platformName}) : _platformName = platformName ?? defaultTargetPlatform.name;
 
   final String _platformName;
 

--- a/test/src/utils/platform_util_test.dart
+++ b/test/src/utils/platform_util_test.dart
@@ -5,37 +5,37 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('PlatformUtil', () {
     test('getCurrentPlatform returns PlatformType.android for android platform', () {
-      final platformUtil = PlatformUtil(platfromName: 'android');
+      final platformUtil = PlatformUtil(platformName: 'android');
       expect(platformUtil.getCurrentPlatform(), equals(PlatformType.android));
     });
 
     test('getCurrentPlatform returns PlatformType.ios for iOS platform', () {
-      final platformUtil = PlatformUtil(platfromName: 'iOS');
+      final platformUtil = PlatformUtil(platformName: 'iOS');
       expect(platformUtil.getCurrentPlatform(), equals(PlatformType.ios));
     });
 
     test('getCurrentPlatform returns PlatformType.linux for linux platform', () {
-      final platformUtil = PlatformUtil(platfromName: 'linux');
+      final platformUtil = PlatformUtil(platformName: 'linux');
       expect(platformUtil.getCurrentPlatform(), equals(PlatformType.linux));
     });
 
     test('getCurrentPlatform returns PlatformType.macos for macOS platform', () {
-      final platformUtil = PlatformUtil(platfromName: 'macOS');
+      final platformUtil = PlatformUtil(platformName: 'macOS');
       expect(platformUtil.getCurrentPlatform(), equals(PlatformType.macos));
     });
 
     test('getCurrentPlatform returns PlatformType.windows for windows platform', () {
-      final platformUtil = PlatformUtil(platfromName: 'windows');
+      final platformUtil = PlatformUtil(platformName: 'windows');
       expect(platformUtil.getCurrentPlatform(), equals(PlatformType.windows));
     });
 
     test('getCurrentPlatform returns PlatformType.web for fuchsia platform', () {
-      final platformUtil = PlatformUtil(platfromName: 'fuchsia');
+      final platformUtil = PlatformUtil(platformName: 'fuchsia');
       expect(platformUtil.getCurrentPlatform(), equals(PlatformType.web));
     });
 
     test('getCurrentPlatform returns PlatformType.web for unknown platform', () {
-      final platformUtil = PlatformUtil(platfromName: 'unknown_platform');
+      final platformUtil = PlatformUtil(platformName: 'unknown_platform');
       expect(platformUtil.getCurrentPlatform(), equals(PlatformType.web));
     });
 


### PR DESCRIPTION
## Summary
- fix incorrect `platfromName` parameter in `PlatformUtil`
- update tests to use `platformName`

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_684178e751ac83338e8b3a74407f383e