### PR TITLE
Add Slack deep links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.1.1
+* Added Slack app with following actions:
+  * Open app
+  * Open Team Action
+  * Open Channel Action
+  * Open User Action
+* Added documentation for Slack deeplinks
+* Updated example app with Slack tab
+
 ## 1.1.0
 * Now DeeplinkX is more reliable for 100% test coverage
 * Bug Fixes

--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ Easy to use Flutter plugin for type-safe handling of external deeplinks with bui
 - Redirect to app stores to update apps
 - Check if external app is installed on the device
 - Smart fallback system
-- Support popular stores and apps including Facebook, Instagram, LinkedIn, WhatsApp, Telegram, Twitter, and YouTube
-- Support popular stores and apps including Facebook, Instagram, LinkedIn, WhatsApp, Telegram, Twitter, TikTok, Pinterest, and Zoom
+- Support popular stores and apps including Facebook, Instagram, LinkedIn, WhatsApp, Telegram, Twitter, YouTube, Pinterest, TikTok, Zoom, and Slack
 
 ## Usage
 
@@ -108,6 +107,7 @@ final isRedirected = await deeplinkX.redirectToStore(
 | Social Apps | Pinterest               | • Open profile by username<br>• Open board by ID<br>• Search                                      |
 | Social Apps | TikTok                  | • Open profile by username<br>• Open video<br>• Open Tag                                          |
 | Social Apps | Zoom                    | • Join meeting by ID                                                                              |
+| Social Apps | Slack                   | • Open team<br>• Open channel<br>• Open user |
 | Business    | LinkedIn                | • Open profile page<br>• Open company page                                                        |
 
 ## Documentation
@@ -131,6 +131,7 @@ Detailed documentation available in [doc/apps](https://github.com/DeeplinkX/Deep
 - [Pinterest](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/pinterest.md)
 - [TikTok](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/tiktok.md)
 - [Zoom](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/zoom.md)
+- [Slack](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/slack.md)
 
 ## URL Scheme Handling
 

--- a/doc/apps/slack.md
+++ b/doc/apps/slack.md
@@ -1,0 +1,146 @@
+# Slack Deeplinks
+
+DeeplinkX provides support for Slack deep linking actions.
+
+## Available Actions
+
+### Launch Slack App
+```dart
+final deeplinkX = DeeplinkX();
+
+// Simple launch
+await deeplinkX.launchApp(Slack.open());
+
+// Launch with store fallback if not installed
+await deeplinkX.launchApp(Slack.open(fallbackToStore: true));
+
+// Launch with fallback disabled
+await deeplinkX.launchApp(Slack.open(), disableFallback: true);
+```
+
+### Open Team Action
+```dart
+final deeplinkX = DeeplinkX();
+
+await deeplinkX.launchAction(
+  Slack.openTeam(teamId: 'T123456'),
+);
+```
+
+### Open Channel Action
+```dart
+final deeplinkX = DeeplinkX();
+
+await deeplinkX.launchAction(
+  Slack.openChannel(
+    teamId: 'T123456',
+    channelId: 'C123456',
+  ),
+);
+```
+
+### Open User Action
+```dart
+final deeplinkX = DeeplinkX();
+
+await deeplinkX.launchAction(
+  Slack.openUser(
+    teamId: 'T123456',
+    userId: 'U123456',
+  ),
+);
+```
+
+## Platform-Specific Configuration
+
+### iOS
+Add the following to your `ios/Runner/Info.plist`:
+```xml
+<key>LSApplicationQueriesSchemes</key>
+<array>
+    <string>slack</string>
+    <string>itms-apps</string>
+</array>
+```
+
+### Android
+Add the following to your `android/app/src/main/AndroidManifest.xml` inside the `<queries>` tag:
+```xml
+<queries>
+    <!-- For Slack app -->
+    <package android:name="com.Slack" />
+
+    <!-- For Play Store fallback (if using fallbackToStore) -->
+    <package android:name="com.android.vending" />
+
+    <!-- For web fallback (required) -->
+    <intent>
+        <action android:name="android.intent.action.VIEW" />
+        <data android:scheme="https" />
+    </intent>
+</queries>
+```
+
+### macOS
+Add the following to your `macos/Runner/Info.plist`:
+```xml
+<key>LSApplicationQueriesSchemes</key>
+<array>
+    <string>slack</string>
+    <string>macappstore</string>
+</array>
+```
+
+## URL Schemes
+
+DeeplinkX uses the following URL schemes for Slack:
+
+### Native App Deep Links
+When Slack is installed, the following scheme is used:
+- `slack://` - Native Slack URL scheme
+- Open team: `slack://open?team={teamId}`
+- Open channel: `slack://channel?team={teamId}&id={channelId}`
+- Open user: `slack://user?team={teamId}&id={userId}`
+
+### Web Fallback URLs
+When Slack is not installed, DeeplinkX automatically falls back to:
+- `https://slack.com/app_redirect?team={teamId}`
+- For channels: `https://slack.com/app_redirect?team={teamId}&channel={channelId}`
+- For users: `https://slack.com/app_redirect?team={teamId}&channel={userId}`
+
+## Supported Fallback Stores
+When the Slack app is not installed, DeeplinkX can redirect users to download Slack from the following app stores:
+
+- iOS App Store
+- Google Play Store
+- Microsoft Store
+- Mac App Store
+
+To enable fallback to app stores, use the `fallbackToStore` parameter:
+```dart
+final deeplinkX = DeeplinkX();
+await deeplinkX.launchApp(Slack.open(fallbackToStore: true));
+```
+
+## Fallback Behavior
+DeeplinkX follows this sequence when handling Slack deeplinks:
+
+1. It first attempts to launch the Slack app if it's installed on the device.
+2. If the Slack app is not installed and `fallbackToStore` is set to `true`, it will redirect to the appropriate app store based on the user's platform.
+3. If no supported store is available or the store app cannot be launched, it will fall back to opening the Slack web interface in the default browser.
+4. You can disable all fallbacks by setting `disableFallback: true` in the launch methods.
+
+## Fallback Support for Actions
+
+| Action      | Store Fallback | Web Fallback |
+| ----------- | -------------- | ------------ |
+| open        | ✅              | ✅            |
+| openTeam    | ✅              | ✅            |
+| openChannel | ✅              | ✅            |
+| openUser    | ✅              | ✅            |
+
+## Check If Slack Is Installed
+```dart
+final deeplinkX = DeeplinkX();
+final isInstalled = await deeplinkX.isAppInstalled(Slack());
+```

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -52,6 +52,8 @@
         <package android:name="com.zhiliaoapp.musically" />
         <!-- Zoom -->
         <package android:name="us.zoom.videomeetings" />
+        <!-- Slack -->
+        <package android:name="com.Slack" />
 
         <!-- For store apps -->
         <!-- Google Play Store -->

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -55,8 +55,9 @@
 			<string>youtube</string>
 			<string>twitter</string>
 			<string>pinterest</string>
-			<string>tiktok</string>
-			<string>zoomus</string>
-		</array>
+                        <string>tiktok</string>
+                        <string>zoomus</string>
+                        <string>slack</string>
+                </array>
 	</dict>
 </plist>

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -102,6 +102,11 @@ class _MyAppState extends State<MyApp> {
   final _zoomPasswordController = TextEditingController(text: 'abc123');
   final _zoomDisplayNameController = TextEditingController(text: 'John Doe');
 
+  // Slack controllers
+  final _slackTeamIdController = TextEditingController(text: 'T123456');
+  final _slackChannelIdController = TextEditingController(text: 'C123456');
+  final _slackUserIdController = TextEditingController(text: 'U123456');
+
   // FallBackToStore flags
   bool _instagramFallBackToStore = true;
   bool _telegramFallBackToStore = true;
@@ -113,6 +118,7 @@ class _MyAppState extends State<MyApp> {
   bool _pinterestFallBackToStore = true;
   bool _tiktokFallBackToStore = true;
   bool _zoomFallBackToStore = true;
+  bool _slackFallBackToStore = true;
 
   @override
   void dispose() {
@@ -165,6 +171,9 @@ class _MyAppState extends State<MyApp> {
     _zoomMeetingIdController.dispose();
     _zoomPasswordController.dispose();
     _zoomDisplayNameController.dispose();
+    _slackTeamIdController.dispose();
+    _slackChannelIdController.dispose();
+    _slackUserIdController.dispose();
     super.dispose();
   }
 
@@ -172,7 +181,7 @@ class _MyAppState extends State<MyApp> {
   Widget build(final BuildContext context) => MaterialApp(
     theme: ThemeData(primarySwatch: Colors.blue, useMaterial3: true),
     home: DefaultTabController(
-      length: 17,
+      length: 18,
       child: Scaffold(
         appBar: AppBar(
           title: const Text('DeeplinkX Example'),
@@ -189,6 +198,7 @@ class _MyAppState extends State<MyApp> {
               Tab(text: 'Pinterest'),
               Tab(text: 'TikTok'),
               Tab(text: 'Zoom'),
+              Tab(text: 'Slack'),
               Tab(text: 'iOS App Store'),
               Tab(text: 'Play Store'),
               Tab(text: 'Mac App Store'),
@@ -211,6 +221,7 @@ class _MyAppState extends State<MyApp> {
             _buildPinterestTab(),
             _buildTikTokTab(),
             _buildZoomTab(),
+            _buildSlackTab(),
             _buildAppStoreTab(),
             _buildPlayStoreTab(),
             _buildMacAppStoreTab(),
@@ -1875,6 +1886,121 @@ class _MyAppState extends State<MyApp> {
           }
         },
         child: const Text('Join Meeting'),
+      ),
+    ],
+  );
+
+  Widget _buildSlackTab() => SingleChildScrollView(
+    padding: const EdgeInsets.all(16),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Row(
+          children: [
+            const Text('Fallback to App Store:', style: TextStyle(fontSize: 16)),
+            const SizedBox(width: 8),
+            Switch(
+              value: _slackFallBackToStore,
+              onChanged: (final value) => setState(() => _slackFallBackToStore = value),
+            ),
+            const Expanded(
+              child: Text(
+                'When enabled, redirects to app store if Slack is not installed',
+                style: TextStyle(fontSize: 12, color: Colors.grey),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 24),
+        const Text('Slack Actions', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+        const SizedBox(height: 24),
+        _buildSlackActions(),
+      ],
+    ),
+  );
+
+  Widget _buildSlackActions() => Column(
+    crossAxisAlignment: CrossAxisAlignment.stretch,
+    children: [
+      ElevatedButton(
+        onPressed: () async {
+          await _deeplinkX.launchApp(Slack.open(fallbackToStore: _slackFallBackToStore));
+        },
+        child: const Text('Open Slack App'),
+      ),
+      const SizedBox(height: 16),
+      const Text('Open Team', style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+      const SizedBox(height: 8),
+      TextField(
+        controller: _slackTeamIdController,
+        decoration: const InputDecoration(
+          labelText: 'Team ID',
+          hintText: 'Enter team ID',
+          border: OutlineInputBorder(),
+        ),
+      ),
+      const SizedBox(height: 8),
+      ElevatedButton(
+        onPressed: () async {
+          if (_slackTeamIdController.text.isNotEmpty) {
+            await _deeplinkX.launchAction(
+              Slack.openTeam(teamId: _slackTeamIdController.text, fallbackToStore: _slackFallBackToStore),
+            );
+          }
+        },
+        child: const Text('Open Team'),
+      ),
+      const SizedBox(height: 16),
+      const Text('Open Channel', style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+      const SizedBox(height: 8),
+      TextField(
+        controller: _slackChannelIdController,
+        decoration: const InputDecoration(
+          labelText: 'Channel ID',
+          hintText: 'Enter channel ID',
+          border: OutlineInputBorder(),
+        ),
+      ),
+      const SizedBox(height: 8),
+      ElevatedButton(
+        onPressed: () async {
+          if (_slackTeamIdController.text.isNotEmpty && _slackChannelIdController.text.isNotEmpty) {
+            await _deeplinkX.launchAction(
+              Slack.openChannel(
+                teamId: _slackTeamIdController.text,
+                channelId: _slackChannelIdController.text,
+                fallbackToStore: _slackFallBackToStore,
+              ),
+            );
+          }
+        },
+        child: const Text('Open Channel'),
+      ),
+      const SizedBox(height: 16),
+      const Text('Open User', style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+      const SizedBox(height: 8),
+      TextField(
+        controller: _slackUserIdController,
+        decoration: const InputDecoration(
+          labelText: 'User ID',
+          hintText: 'Enter user ID',
+          border: OutlineInputBorder(),
+        ),
+      ),
+      const SizedBox(height: 8),
+      ElevatedButton(
+        onPressed: () async {
+          if (_slackTeamIdController.text.isNotEmpty && _slackUserIdController.text.isNotEmpty) {
+            await _deeplinkX.launchAction(
+              Slack.openUser(
+                teamId: _slackTeamIdController.text,
+                userId: _slackUserIdController.text,
+                fallbackToStore: _slackFallBackToStore,
+              ),
+            );
+          }
+        },
+        child: const Text('Open User'),
       ),
     ],
   );

--- a/example/macos/Runner/Info.plist
+++ b/example/macos/Runner/Info.plist
@@ -34,6 +34,7 @@
         <string>tg</string>
         <string>macappstore</string>
         <string>zoomus</string>
+        <string>slack</string>
         </array>
 </dict>
 </plist>

--- a/lib/src/apps/downloadable_apps/downloadable_apps.dart
+++ b/lib/src/apps/downloadable_apps/downloadable_apps.dart
@@ -2,6 +2,7 @@ export 'facebook.dart';
 export 'instagram.dart';
 export 'linkedin.dart';
 export 'pinterest.dart';
+export 'slack.dart';
 export 'telegram.dart';
 export 'tiktok.dart';
 export 'twitter.dart';

--- a/lib/src/apps/downloadable_apps/slack.dart
+++ b/lib/src/apps/downloadable_apps/slack.dart
@@ -1,0 +1,168 @@
+import 'package:deeplink_x/src/src.dart';
+
+/// Slack application.
+class Slack extends App implements DownloadableApp {
+  /// Creates a new [Slack] instance.
+  Slack({this.fallbackToStore = false});
+
+  /// Creates an action to open the Slack app.
+  factory Slack.open({final bool fallbackToStore = false}) => Slack(fallbackToStore: fallbackToStore);
+
+  @override
+  List<StoreOpenAppPageAction> get storeActions => [
+        PlayStore.openAppPage(packageName: 'com.Slack'),
+        IOSAppStore.openAppPage(appId: '618783545', appName: 'slack'),
+        MicrosoftStore.openAppPage(productId: '9wzdncrdk3wp'),
+        MacAppStore.openAppPage(appId: '803453959', appName: 'slack'),
+      ];
+
+  @override
+  String get androidPackageName => 'com.Slack';
+
+  @override
+  String get customScheme => 'slack';
+
+  @override
+  String get macosBundleIdentifier => 'com.tinyspeck.slackmacgap';
+
+  @override
+  List<PlatformType> get supportedPlatforms => [
+        PlatformType.ios,
+        PlatformType.android,
+        PlatformType.macos,
+        PlatformType.windows,
+      ];
+
+  @override
+  bool fallbackToStore;
+
+  @override
+  Uri get website => Uri.parse('https://slack.com');
+
+  /// Opens Slack workspace by team ID.
+  static SlackOpenTeamAction openTeam({
+    required final String teamId,
+    final bool fallbackToStore = false,
+  }) =>
+      SlackOpenTeamAction(teamId: teamId, fallbackToStore: fallbackToStore);
+
+  /// Opens Slack channel by channel ID and team ID.
+  static SlackOpenChannelAction openChannel({
+    required final String teamId,
+    required final String channelId,
+    final bool fallbackToStore = false,
+  }) =>
+      SlackOpenChannelAction(
+        teamId: teamId,
+        channelId: channelId,
+        fallbackToStore: fallbackToStore,
+      );
+
+  /// Opens Slack direct message with user ID.
+  static SlackOpenUserAction openUser({
+    required final String teamId,
+    required final String userId,
+    final bool fallbackToStore = false,
+  }) =>
+      SlackOpenUserAction(
+        teamId: teamId,
+        userId: userId,
+        fallbackToStore: fallbackToStore,
+      );
+}
+
+/// Action to open a specific team in Slack.
+class SlackOpenTeamAction extends Slack implements AppLinkAppAction, Fallbackable {
+  /// Creates a new [SlackOpenTeamAction].
+  SlackOpenTeamAction({required this.teamId, required super.fallbackToStore});
+
+  /// The ID of the Slack team to open.
+  final String teamId;
+
+  @override
+  Uri get appLink => Uri(scheme: 'slack', host: 'open', queryParameters: {'team': teamId});
+
+  @override
+  Uri get fallbackLink => Uri(
+        scheme: 'https',
+        host: 'slack.com',
+        path: 'app_redirect',
+        queryParameters: {'team': teamId},
+      );
+}
+
+/// Action to open a Slack channel.
+class SlackOpenChannelAction extends Slack implements AppLinkAppAction, Fallbackable {
+  /// Creates a new [SlackOpenChannelAction].
+  SlackOpenChannelAction({
+    required this.teamId,
+    required this.channelId,
+    required super.fallbackToStore,
+  });
+
+  /// The team ID of the workspace.
+  final String teamId;
+
+  /// The channel ID to open.
+  final String channelId;
+
+  @override
+  Uri get appLink => Uri(
+        scheme: 'slack',
+        host: 'channel',
+        queryParameters: {
+          'team': teamId,
+          'id': channelId,
+        },
+      );
+
+  @override
+  Uri get fallbackLink => Uri(
+        scheme: 'https',
+        host: 'slack.com',
+        path: 'app_redirect',
+        queryParameters: {
+          'team': teamId,
+          'channel': channelId,
+        },
+      );
+}
+
+/// Action to open a Slack direct message.
+///
+/// Opens a direct message with the given user ID on the specified team.
+class SlackOpenUserAction extends Slack implements AppLinkAppAction, Fallbackable {
+  /// Creates a new [SlackOpenUserAction].
+  SlackOpenUserAction({
+    required this.teamId,
+    required this.userId,
+    required super.fallbackToStore,
+  });
+
+  /// The team ID of the workspace.
+  final String teamId;
+
+  /// The user ID to open the DM with.
+  final String userId;
+
+  @override
+  Uri get appLink => Uri(
+        scheme: 'slack',
+        host: 'user',
+        queryParameters: {
+          'team': teamId,
+          'id': userId,
+        },
+      );
+
+  @override
+  Uri get fallbackLink => Uri(
+        scheme: 'https',
+        host: 'slack.com',
+        path: 'app_redirect',
+        queryParameters: {
+          'team': teamId,
+          'channel': userId,
+        },
+      );
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: deeplink_x
 description: Easy to use Flutter plugin for type-safe external deeplink launching with built-in smart fallback, supporting app stores and popular apps.
-version: 1.1.0
+version: 1.1.1
 
 repository: https://github.com/DeepLinkX/DeeplinkX
 issue_tracker: https://github.com/DeepLinkX/DeeplinkX/issues

--- a/test/deeplink_x_test.dart
+++ b/test/deeplink_x_test.dart
@@ -86,6 +86,11 @@ void main() {
         expect(action, isA<App>());
       });
 
+      test('Slack', () {
+        final action = Slack.open();
+        expect(action, isA<App>());
+      });
+
       test('Pinterest', () {
         final action = Pinterest.open();
         expect(action, isA<App>());

--- a/test/src/apps/slack_test.dart
+++ b/test/src/apps/slack_test.dart
@@ -1,0 +1,68 @@
+import 'package:deeplink_x/src/apps/app_stores/ios_app_store.dart';
+import 'package:deeplink_x/src/apps/app_stores/mac_app_store.dart';
+import 'package:deeplink_x/src/apps/app_stores/microsoft_store.dart';
+import 'package:deeplink_x/src/apps/app_stores/play_store.dart';
+import 'package:deeplink_x/src/apps/downloadable_apps/slack.dart';
+import 'package:deeplink_x/src/core/enums/platform_type.dart';
+import 'package:deeplink_x/src/core/interfaces/app_interface.dart';
+import 'package:deeplink_x/src/core/interfaces/downloadable_app_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Slack Actions', () {
+    test('open action creates Slack instance with correct properties', () {
+      final action = Slack.open();
+
+      expect(action.customScheme, 'slack');
+      expect(action.androidPackageName, 'com.Slack');
+      expect(action.website.toString(), 'https://slack.com');
+      expect(action.supportedPlatforms, contains(PlatformType.android));
+      expect(action.supportedPlatforms, contains(PlatformType.ios));
+      expect(action.supportedPlatforms, contains(PlatformType.macos));
+      expect(action.supportedPlatforms, contains(PlatformType.windows));
+      expect(action.supportedPlatforms.length, 4);
+      expect(action.macosBundleIdentifier, 'com.tinyspeck.slackmacgap');
+
+      expect(action.fallbackToStore, false);
+      expect(action.storeActions.length, 4);
+    });
+
+    test('open action creates Slack instance with correct type', () {
+      final action = Slack.open();
+
+      expect(action, isA<App>());
+      expect(action, isA<DownloadableApp>());
+    });
+
+    test('openTeam action creates correct URIs', () {
+      final action = Slack.openTeam(teamId: 'T123');
+
+      expect(action.appLink.toString(), 'slack://open?team=T123');
+      expect(action.fallbackLink.toString(), 'https://slack.com/app_redirect?team=T123');
+    });
+
+    test('openChannel action creates correct URIs', () {
+      final action = Slack.openChannel(teamId: 'T123', channelId: 'C456');
+
+      expect(action.appLink.toString(), 'slack://channel?team=T123&id=C456');
+      expect(action.fallbackLink.toString(), 'https://slack.com/app_redirect?team=T123&channel=C456');
+    });
+
+    test('openUser action creates correct URIs', () {
+      final action = Slack.openUser(teamId: 'T123', userId: 'U789');
+
+      expect(action.appLink.toString(), 'slack://user?team=T123&id=U789');
+      expect(action.fallbackLink.toString(), 'https://slack.com/app_redirect?team=T123&channel=U789');
+    });
+
+    test('store actions have correct properties', () {
+      final slack = Slack();
+      final storeActions = slack.storeActions;
+
+      expect(storeActions[0], isA<PlayStoreOpenAppPageAction>());
+      expect(storeActions[1], isA<IOSAppStoreOpenAppPageAction>());
+      expect(storeActions[2], isA<MicrosoftStoreOpenAppPageAction>());
+      expect(storeActions[3], isA<MacAppStoreOpenAppPageAction>());
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add Slack downloadable app implementation
- support Slack openTeam, openChannel and openUser actions
- document Slack configuration
- expose Slack in public API tests
- add Slack examples and platform configs
- bump version to 1.1.1

## Testing
- `flutter analyze`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_684830e57120833391ead33337267927