### PR TITLE
[codex] Add map launch utilities

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,11 +16,13 @@ When introducing a new navigation app (e.g. Maps providers), follow this checkli
    - Wire exports via `lib/src/apps/downloadable_apps/downloadable_apps.dart`.
    - Ensure custom schemes, store actions, supported platforms, and fallback links are defined.
    - Align navigation APIs with the existing pattern: provide at least a `view` action plus `directionsWithCoords` (or platform-equivalent) so navigation workflows stay consistent.
+   - Implement the relevant map action abstractions (`MapViewAction`, `MapSearchAction`, `MapDirectionsAction`, `MapDirectionsWithCoordsAction`) on each navigation action so the shared map launch utilities can use it.
    - Reuse the established naming for navigation actions across code and docs (`View map`, `Search`, `Directions`, `Directions with coordinates`) so README tables, doc pages, changelog entries, and example labels stay in sync.
 
 2. **Documentation**
    - Add a dedicated page in `doc/apps/` describing usage, configuration, and URL schemes.
    - Reference the new app everywhere it appears in `README.md` (feature bullet list, supported apps table, documentation list, etc.).
+   - Add the new provider action to the README map launch utility examples when it supports one of the shared map action abstractions.
 
 3. **Example App**
    - Provide a sample page in `example/lib/pages/` that demonstrates all supported actions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 1.3.0
+
+* Added map action abstractions for navigation providers:
+  * `MapAppAction`
+  * `MapViewAction`
+  * `MapSearchAction`
+  * `MapDirectionsAction`
+  * `MapDirectionsWithCoordsAction`
+* Added typed map launch utilities to `DeeplinkX`:
+  * `launchMapViewAction`
+  * `launchMapSearchAction`
+  * `launchMapDirectionsAction`
+  * `launchMapDirectionsWithCoordsAction`
+* Updated README examples and AGENTS navigation-app guidance
+* Added tests for map abstractions, launch utilities, and public API coverage
+
 ## 1.2.0
 
 * Bump dependency deeplink_x_macos version to 0.2.0 ([#Change](https://pub.dev/packages/deeplink_x_macos/changelog#020))

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Easy to use Flutter plugin for type-safe handling of external deeplinks with bui
 - [Usage](#usage)
 - [Supported Apps And Actions](#supported-apps-and-actions)
 - [Documentation](#documentation)
+- [Launch Utilities](#launch-utilities)
 - [URL Scheme Handling](#url-scheme-handling)
 - [Platform-Specific Configuration](#platform-specific-configuration)
 - [Why Prefer Custom Schemes, App Links or Intent Actions Instead of Universal Links?](#why-prefer-custom-schemes-app-links-or-intent-actions-instead-of-universal-links)
@@ -36,6 +37,7 @@ Easy to use Flutter plugin for type-safe handling of external deeplinks with bui
 - Launch deeplink actions within apps
 - Launch apps without specific actions
 - Redirect to app stores to update apps
+- Launch utilities for store redirects and ordered map provider fallback
 - Check if external app is installed on the device
 - Smart fallback system
 - Support popular stores including Google PlayStore, iOS AppStore, Mac AppStore, Microsoft Store, Huawei AppGallery, Myket, Cafe Bazaar
@@ -135,21 +137,6 @@ Verify if a specific app is installed on the device:
 final isInstalled = await deeplinkX.isAppInstalled(LinkedIn());
 ```
 
-### Redirect To Store
-
-Redirect users to appropriate app stores based on their platform:
-
-```dart
-// Redirect to appropriate store based on current platform
-final isRedirected = await deeplinkX.redirectToStore(
-  storeActions: [
-    IOSAppStore.openAppPage(appId: '389801252', appName: 'instagram'),  // iOS App Store
-    PlayStore.openAppPage(packageName: 'com.instagram.android'),  // Google Play Store
-    HuaweiAppGalleryStore.openAppPage(appId: 'C101162369'),  // Huawei AppGallery Store
-  ],
-);
-```
-
 ## Supported Apps And Actions
 
 | Category    | App                     | Supported Actions                                                                                 |
@@ -203,6 +190,71 @@ Detailed documentation available in [doc/apps](https://github.com/DeeplinkX/Deep
 - [Waze](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/waze.md)
 - [Apple Maps](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/apple_maps.md)
 - [Sygic](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/sygic.md)
+
+## Launch Utilities
+
+### Store Redirect
+
+Redirect users to appropriate app stores based on their platform:
+
+```dart
+// Redirect to appropriate store based on current platform
+final isRedirected = await deeplinkX.redirectToStore(
+  storeActions: [
+    IOSAppStore.openAppPage(appId: '389801252', appName: 'instagram'),  // iOS App Store
+    PlayStore.openAppPage(packageName: 'com.instagram.android'),  // Google Play Store
+    HuaweiAppGalleryStore.openAppPage(appId: 'C101162369'),  // Huawei AppGallery Store
+  ],
+);
+```
+
+### Map Provider Launching
+
+Use map launch utilities when several navigation apps can handle the same
+action. DeeplinkX tries the actions in the order you provide, so the list stays
+caller-owned and can grow as new map providers are added.
+
+```dart
+const currentLocation = Coordinate(latitude: 35.6892, longitude: 51.3890);
+const destination = Coordinate(latitude: 35.7000, longitude: 51.4000);
+
+await deeplinkX.launchMapViewAction(
+  actions: [
+    GoogleMaps.view(coordinate: currentLocation),
+    AppleMaps.view(coordinate: currentLocation),
+  ],
+);
+
+await deeplinkX.launchMapSearchAction(
+  actions: [
+    GoogleMaps.search(query: 'Central Park'),
+    AppleMaps.search(query: 'Central Park'),
+  ],
+);
+
+await deeplinkX.launchMapDirectionsAction(
+  actions: [
+    GoogleMaps.directions(destination: 'Central Park'),
+    AppleMaps.directions(destination: 'Central Park'),
+  ],
+);
+
+await deeplinkX.launchMapDirectionsWithCoordsAction(
+  actions: [
+    GoogleMaps.directionsWithCoords(destination: destination),
+    AppleMaps.directionsWithCoords(destination: destination),
+  ],
+);
+```
+
+Supported apps:
+
+| Method | Supported apps |
+| ------ | -------------- |
+| `launchMapViewAction` | Google Maps, Apple Maps, Waze, Sygic |
+| `launchMapSearchAction` | Google Maps, Apple Maps, Waze |
+| `launchMapDirectionsAction` | Google Maps, Apple Maps, Waze |
+| `launchMapDirectionsWithCoordsAction` | Google Maps, Apple Maps, Waze, Sygic |
 
 ## URL Scheme Handling
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -71,7 +71,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.2.0"
+    version: "1.3.0"
   deeplink_x_android:
     dependency: transitive
     description:
@@ -226,10 +226,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -335,10 +335,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.10"
   url_launcher:
     dependency: transitive
     description:

--- a/lib/src/apps/downloadable_apps/apple_maps.dart
+++ b/lib/src/apps/downloadable_apps/apple_maps.dart
@@ -111,7 +111,7 @@ enum AppleMapsTransportType {
 }
 
 /// Apple Maps search action using custom scheme.
-class AppleMapsSearchAction extends AppleMaps implements AppLinkAppAction, Fallbackable {
+class AppleMapsSearchAction extends AppleMaps implements AppLinkAppAction, Fallbackable, MapSearchAction {
   /// Creates a new [AppleMapsSearchAction].
   AppleMapsSearchAction({
     required this.query,
@@ -119,6 +119,7 @@ class AppleMapsSearchAction extends AppleMaps implements AppLinkAppAction, Fallb
   });
 
   /// Search query.
+  @override
   final String query;
 
   @override
@@ -141,7 +142,7 @@ class AppleMapsSearchAction extends AppleMaps implements AppLinkAppAction, Fallb
 }
 
 /// Apple Maps view action.
-class AppleMapsViewAction extends AppleMaps implements AppLinkAppAction, Fallbackable {
+class AppleMapsViewAction extends AppleMaps implements AppLinkAppAction, Fallbackable, MapViewAction {
   /// Creates a new [AppleMapsViewAction].
   AppleMapsViewAction({
     required this.coordinate,
@@ -150,6 +151,7 @@ class AppleMapsViewAction extends AppleMaps implements AppLinkAppAction, Fallbac
   });
 
   /// Map center coordinate.
+  @override
   final Coordinate coordinate;
 
   /// Optional zoom.
@@ -177,7 +179,7 @@ class AppleMapsViewAction extends AppleMaps implements AppLinkAppAction, Fallbac
 }
 
 /// Apple Maps directions action using addresses/place names.
-class AppleMapsDirectionsAction extends AppleMaps implements AppLinkAppAction, Fallbackable {
+class AppleMapsDirectionsAction extends AppleMaps implements AppLinkAppAction, Fallbackable, MapDirectionsAction {
   /// Creates a new [AppleMapsDirectionsAction].
   AppleMapsDirectionsAction({
     required this.destination,
@@ -187,6 +189,7 @@ class AppleMapsDirectionsAction extends AppleMaps implements AppLinkAppAction, F
   });
 
   /// Destination address or name.
+  @override
   final String destination;
 
   /// Optional origin address or name.
@@ -219,7 +222,8 @@ class AppleMapsDirectionsAction extends AppleMaps implements AppLinkAppAction, F
 }
 
 /// Apple Maps directions action using coordinates.
-class AppleMapsDirectionsWithCoordsAction extends AppleMaps implements AppLinkAppAction, Fallbackable {
+class AppleMapsDirectionsWithCoordsAction extends AppleMaps
+    implements AppLinkAppAction, Fallbackable, MapDirectionsWithCoordsAction {
   /// Creates a new [AppleMapsDirectionsWithCoordsAction].
   AppleMapsDirectionsWithCoordsAction({
     required this.destination,
@@ -229,6 +233,7 @@ class AppleMapsDirectionsWithCoordsAction extends AppleMaps implements AppLinkAp
   });
 
   /// Destination coordinates.
+  @override
   final Coordinate destination;
 
   /// Optional origin coordinates.

--- a/lib/src/apps/downloadable_apps/google_maps.dart
+++ b/lib/src/apps/downloadable_apps/google_maps.dart
@@ -165,7 +165,8 @@ enum GoogleMapsTravelMode {
 ///
 /// This class extends [GoogleMaps] and implements multiple interfaces to provide
 /// comprehensive functionality for searching with fallback support.
-class GoogleMapsSearchAction extends GoogleMaps implements IntentAppLinkAction, AppLinkAppAction, Fallbackable {
+class GoogleMapsSearchAction extends GoogleMaps
+    implements IntentAppLinkAction, AppLinkAppAction, Fallbackable, MapSearchAction {
   /// Creates a new [GoogleMapsSearchAction] instance.
   ///
   /// Parameters:
@@ -178,6 +179,7 @@ class GoogleMapsSearchAction extends GoogleMaps implements IntentAppLinkAction, 
   });
 
   /// The search query.
+  @override
   final String query;
 
   @override
@@ -211,7 +213,8 @@ class GoogleMapsSearchAction extends GoogleMaps implements IntentAppLinkAction, 
 }
 
 /// An action to display a map centered on specific coordinates.
-class GoogleMapsViewAction extends GoogleMaps implements IntentAppLinkAction, AppLinkAppAction, Fallbackable {
+class GoogleMapsViewAction extends GoogleMaps
+    implements IntentAppLinkAction, AppLinkAppAction, Fallbackable, MapViewAction {
   /// Creates a new [GoogleMapsViewAction] instance.
   GoogleMapsViewAction({
     required this.coordinate,
@@ -220,6 +223,7 @@ class GoogleMapsViewAction extends GoogleMaps implements IntentAppLinkAction, Ap
   });
 
   /// Coordinate to center the map on.
+  @override
   final Coordinate coordinate;
 
   /// Optional zoom level.
@@ -257,7 +261,8 @@ class GoogleMapsViewAction extends GoogleMaps implements IntentAppLinkAction, Ap
 }
 
 /// An action to get directions using addresses or place IDs.
-class GoogleMapsDirectionsAction extends GoogleMaps implements IntentAppLinkAction, AppLinkAppAction, Fallbackable {
+class GoogleMapsDirectionsAction extends GoogleMaps
+    implements IntentAppLinkAction, AppLinkAppAction, Fallbackable, MapDirectionsAction {
   /// Creates a new [GoogleMapsDirectionsAction] instance.
   GoogleMapsDirectionsAction({
     required this.destination,
@@ -267,6 +272,7 @@ class GoogleMapsDirectionsAction extends GoogleMaps implements IntentAppLinkActi
   });
 
   /// Destination address or place name.
+  @override
   final String destination;
 
   /// Optional origin address or place name.
@@ -319,7 +325,7 @@ class GoogleMapsDirectionsAction extends GoogleMaps implements IntentAppLinkActi
 
 /// An action to get directions using coordinates.
 class GoogleMapsDirectionsWithCoordsAction extends GoogleMaps
-    implements IntentAppLinkAction, AppLinkAppAction, Fallbackable {
+    implements IntentAppLinkAction, AppLinkAppAction, Fallbackable, MapDirectionsWithCoordsAction {
   /// Creates a new [GoogleMapsDirectionsWithCoordsAction] instance.
   GoogleMapsDirectionsWithCoordsAction({
     required this.destination,
@@ -329,6 +335,7 @@ class GoogleMapsDirectionsWithCoordsAction extends GoogleMaps
   });
 
   /// Destination coordinates.
+  @override
   final Coordinate destination;
 
   /// Optional origin coordinates.

--- a/lib/src/apps/downloadable_apps/sygic.dart
+++ b/lib/src/apps/downloadable_apps/sygic.dart
@@ -81,7 +81,7 @@ enum SygicTransportMode {
 }
 
 /// Sygic show coordinate action.
-class SygicViewAction extends Sygic implements AppLinkAppAction, Fallbackable {
+class SygicViewAction extends Sygic implements AppLinkAppAction, Fallbackable, MapViewAction {
   /// Creates a new [SygicViewAction].
   SygicViewAction({
     required this.coordinate,
@@ -89,6 +89,7 @@ class SygicViewAction extends Sygic implements AppLinkAppAction, Fallbackable {
   });
 
   /// Coordinate to show on the map.
+  @override
   final Coordinate coordinate;
 
   @override
@@ -106,7 +107,8 @@ class SygicViewAction extends Sygic implements AppLinkAppAction, Fallbackable {
 }
 
 /// Sygic turn-by-turn navigation action.
-class SygicDirectionsWithCoordsAction extends Sygic implements AppLinkAppAction, Fallbackable {
+class SygicDirectionsWithCoordsAction extends Sygic
+    implements AppLinkAppAction, Fallbackable, MapDirectionsWithCoordsAction {
   /// Creates a new [SygicDirectionsWithCoordsAction].
   SygicDirectionsWithCoordsAction({
     required this.destination,
@@ -115,6 +117,7 @@ class SygicDirectionsWithCoordsAction extends Sygic implements AppLinkAppAction,
   });
 
   /// Destination coordinate.
+  @override
   final Coordinate destination;
 
   /// Selected transport mode.

--- a/lib/src/apps/downloadable_apps/waze.dart
+++ b/lib/src/apps/downloadable_apps/waze.dart
@@ -90,7 +90,7 @@ class Waze extends App implements DownloadableApp {
 }
 
 /// Waze view map action using universal link.
-class WazeViewAction extends Waze implements UniversalLinkAppAction, Fallbackable {
+class WazeViewAction extends Waze implements UniversalLinkAppAction, Fallbackable, MapViewAction {
   /// Creates a new [WazeViewAction].
   WazeViewAction({
     required this.coordinate,
@@ -98,6 +98,7 @@ class WazeViewAction extends Waze implements UniversalLinkAppAction, Fallbackabl
   });
 
   /// Map center coordinate.
+  @override
   final Coordinate coordinate;
 
   @override
@@ -115,7 +116,7 @@ class WazeViewAction extends Waze implements UniversalLinkAppAction, Fallbackabl
 }
 
 /// Waze search action using universal link. No web fallback provided.
-class WazeSearchAction extends Waze implements UniversalLinkAppAction {
+class WazeSearchAction extends Waze implements UniversalLinkAppAction, MapSearchAction {
   /// Creates a new [WazeSearchAction].
   WazeSearchAction({
     required this.query,
@@ -123,6 +124,7 @@ class WazeSearchAction extends Waze implements UniversalLinkAppAction {
   });
 
   /// Search query string (q).
+  @override
   final String query;
 
   @override
@@ -137,7 +139,7 @@ class WazeSearchAction extends Waze implements UniversalLinkAppAction {
 }
 
 /// Waze directions action to a destination string.
-class WazeDirectionsAction extends Waze implements UniversalLinkAppAction, Fallbackable {
+class WazeDirectionsAction extends Waze implements UniversalLinkAppAction, Fallbackable, MapDirectionsAction {
   /// Creates a new [WazeDirectionsAction].
   WazeDirectionsAction({
     required this.destination,
@@ -146,6 +148,7 @@ class WazeDirectionsAction extends Waze implements UniversalLinkAppAction, Fallb
   });
 
   /// Destination address or place (q).
+  @override
   final String destination;
 
   /// Optional zoom (z) level.
@@ -168,7 +171,8 @@ class WazeDirectionsAction extends Waze implements UniversalLinkAppAction, Fallb
 }
 
 /// Waze directions action to destination coordinates.
-class WazeDirectionsWithCoordsAction extends Waze implements UniversalLinkAppAction, Fallbackable {
+class WazeDirectionsWithCoordsAction extends Waze
+    implements UniversalLinkAppAction, Fallbackable, MapDirectionsWithCoordsAction {
   /// Creates a new [WazeDirectionsWithCoordsAction].
   WazeDirectionsWithCoordsAction({
     required this.destination,
@@ -177,6 +181,7 @@ class WazeDirectionsWithCoordsAction extends Waze implements UniversalLinkAppAct
   });
 
   /// Destination coordinates (ll).
+  @override
   final Coordinate destination;
 
   /// Optional zoom (z) level.

--- a/lib/src/core/deeplink_x.dart
+++ b/lib/src/core/deeplink_x.dart
@@ -188,4 +188,73 @@ class DeeplinkX {
 
     return false;
   }
+
+  /// Launches the first available map view action from [actions].
+  ///
+  /// Actions are attempted in the provided order. DeeplinkX first tries each
+  /// native map action without fallback, then tries regular fallback behavior
+  /// only if no native launch succeeds.
+  Future<bool> launchMapViewAction({
+    required final List<MapViewAction> actions,
+    final bool disableFallback = false,
+  }) =>
+      _launchMapActions(actions, disableFallback: disableFallback);
+
+  /// Launches the first available map search action from [actions].
+  ///
+  /// Actions are attempted in the provided order. DeeplinkX first tries each
+  /// native map action without fallback, then tries regular fallback behavior
+  /// only if no native launch succeeds.
+  Future<bool> launchMapSearchAction({
+    required final List<MapSearchAction> actions,
+    final bool disableFallback = false,
+  }) =>
+      _launchMapActions(actions, disableFallback: disableFallback);
+
+  /// Launches the first available map directions action from [actions].
+  ///
+  /// Actions are attempted in the provided order. DeeplinkX first tries each
+  /// native map action without fallback, then tries regular fallback behavior
+  /// only if no native launch succeeds.
+  Future<bool> launchMapDirectionsAction({
+    required final List<MapDirectionsAction> actions,
+    final bool disableFallback = false,
+  }) =>
+      _launchMapActions(actions, disableFallback: disableFallback);
+
+  /// Launches the first available coordinate-based map directions action from [actions].
+  ///
+  /// Actions are attempted in the provided order. DeeplinkX first tries each
+  /// native map action without fallback, then tries regular fallback behavior
+  /// only if no native launch succeeds.
+  Future<bool> launchMapDirectionsWithCoordsAction({
+    required final List<MapDirectionsWithCoordsAction> actions,
+    final bool disableFallback = false,
+  }) =>
+      _launchMapActions(actions, disableFallback: disableFallback);
+
+  Future<bool> _launchMapActions<T extends MapAppAction>(
+    final List<T> actions, {
+    required final bool disableFallback,
+  }) async {
+    for (final action in actions) {
+      final isLaunched = await launchAction(action, disableFallback: true);
+      if (isLaunched) {
+        return true;
+      }
+    }
+
+    if (disableFallback) {
+      return false;
+    }
+
+    for (final action in actions) {
+      final isLaunched = await launchAction(action);
+      if (isLaunched) {
+        return true;
+      }
+    }
+
+    return false;
+  }
 }

--- a/lib/src/core/interfaces/interfaces.dart
+++ b/lib/src/core/interfaces/interfaces.dart
@@ -4,6 +4,7 @@ export 'app_link_app_action_interface.dart';
 export 'downloadable_app_interface.dart';
 export 'fallbackable_interface.dart';
 export 'intent_app_action_interface.dart';
+export 'map_app_action_interface.dart';
 export 'store_app_interface.dart';
 export 'store_open_app_page_action_interface.dart';
 export 'universal_link_app_action_interface.dart';

--- a/lib/src/core/interfaces/map_app_action_interface.dart
+++ b/lib/src/core/interfaces/map_app_action_interface.dart
@@ -1,0 +1,33 @@
+import 'package:deeplink_x/src/core/interfaces/app_action_interface.dart';
+import 'package:deeplink_x/src/core/interfaces/downloadable_app_interface.dart';
+import 'package:deeplink_x/src/core/models/coordinate.dart';
+
+/// Represents a map-specific app action.
+///
+/// Map actions are downloadable app actions that can be grouped and launched
+/// through the map utility methods on DeeplinkX.
+abstract class MapAppAction extends DownloadableApp implements AppAction {}
+
+/// Represents a map action that displays a coordinate.
+abstract class MapViewAction extends MapAppAction {
+  /// Coordinate to display on the map.
+  Coordinate get coordinate;
+}
+
+/// Represents a map action that searches for a query.
+abstract class MapSearchAction extends MapAppAction {
+  /// Search query.
+  String get query;
+}
+
+/// Represents a map action that navigates to a destination string.
+abstract class MapDirectionsAction extends MapAppAction {
+  /// Destination address or place name.
+  String get destination;
+}
+
+/// Represents a map action that navigates to destination coordinates.
+abstract class MapDirectionsWithCoordsAction extends MapAppAction {
+  /// Destination coordinates.
+  Coordinate get destination;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: deeplink_x
 description: Easy to use Flutter plugin for type-safe external deeplink launching with built-in smart fallback, supporting app stores and popular apps.
-version: 1.2.0
+version: 1.3.0
 
 repository: https://github.com/DeepLinkX/DeeplinkX
 issue_tracker: https://github.com/DeepLinkX/DeeplinkX/issues

--- a/test/deeplink_x_test.dart
+++ b/test/deeplink_x_test.dart
@@ -21,6 +21,16 @@ class MockUniversalLinkAppAction extends Mock implements UniversalLinkAppAction 
 
 class MockIntentAppLinkAction extends Mock implements IntentAppLinkAction {}
 
+class MockMapAppAction extends Mock implements MapAppAction {}
+
+class MockMapViewAction extends Mock implements MapViewAction {}
+
+class MockMapSearchAction extends Mock implements MapSearchAction {}
+
+class MockMapDirectionsAction extends Mock implements MapDirectionsAction {}
+
+class MockMapDirectionsWithCoordsAction extends Mock implements MapDirectionsWithCoordsAction {}
+
 class MockDeeplinkX extends Mock implements DeeplinkX {}
 
 // Tests APIs exposed correctly
@@ -204,6 +214,42 @@ void main() {
         final result = await deeplinkX.redirectToStore(storeActions: [MockStoreOpenAppPageAction()]);
         expect(result, true);
       });
+
+      test('launchMapViewAction', () async {
+        final actions = <MapViewAction>[];
+        when(() => deeplinkX.launchMapViewAction(actions: actions)).thenAnswer((final _) async => true);
+
+        final result = await deeplinkX.launchMapViewAction(actions: actions);
+
+        expect(result, true);
+      });
+
+      test('launchMapSearchAction', () async {
+        final actions = <MapSearchAction>[];
+        when(() => deeplinkX.launchMapSearchAction(actions: actions)).thenAnswer((final _) async => true);
+
+        final result = await deeplinkX.launchMapSearchAction(actions: actions);
+
+        expect(result, true);
+      });
+
+      test('launchMapDirectionsAction', () async {
+        final actions = <MapDirectionsAction>[];
+        when(() => deeplinkX.launchMapDirectionsAction(actions: actions)).thenAnswer((final _) async => true);
+
+        final result = await deeplinkX.launchMapDirectionsAction(actions: actions);
+
+        expect(result, true);
+      });
+
+      test('launchMapDirectionsWithCoordsAction', () async {
+        final actions = <MapDirectionsWithCoordsAction>[];
+        when(() => deeplinkX.launchMapDirectionsWithCoordsAction(actions: actions)).thenAnswer((final _) async => true);
+
+        final result = await deeplinkX.launchMapDirectionsWithCoordsAction(actions: actions);
+
+        expect(result, true);
+      });
     });
 
     group('Interfaces:', () {
@@ -256,6 +302,45 @@ void main() {
         when(() => mock.appLink).thenReturn(Uri.parse('test://test'));
 
         expect(mock.appLink.toString(), 'test://test');
+      });
+
+      test('MapAppAction', () {
+        final mock = MockMapAppAction();
+        expect(mock, isA<MapAppAction>());
+      });
+
+      test('MapViewAction', () {
+        final mock = MockMapViewAction();
+        const coordinate = Coordinate(latitude: 1, longitude: 2);
+        when(() => mock.coordinate).thenReturn(coordinate);
+
+        expect(mock, isA<MapViewAction>());
+        expect(mock.coordinate, coordinate);
+      });
+
+      test('MapSearchAction', () {
+        final mock = MockMapSearchAction();
+        when(() => mock.query).thenReturn('Central Park');
+
+        expect(mock, isA<MapSearchAction>());
+        expect(mock.query, 'Central Park');
+      });
+
+      test('MapDirectionsAction', () {
+        final mock = MockMapDirectionsAction();
+        when(() => mock.destination).thenReturn('Central Park');
+
+        expect(mock, isA<MapDirectionsAction>());
+        expect(mock.destination, 'Central Park');
+      });
+
+      test('MapDirectionsWithCoordsAction', () {
+        final mock = MockMapDirectionsWithCoordsAction();
+        const destination = Coordinate(latitude: 1, longitude: 2);
+        when(() => mock.destination).thenReturn(destination);
+
+        expect(mock, isA<MapDirectionsWithCoordsAction>());
+        expect(mock.destination, destination);
       });
 
       test('Fallbackable', () {

--- a/test/src/apps/map_actions_test.dart
+++ b/test/src/apps/map_actions_test.dart
@@ -1,0 +1,34 @@
+import 'package:deeplink_x/deeplink_x.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Map action abstractions', () {
+    const coordinate = Coordinate(latitude: 1, longitude: 2);
+
+    test('Google Maps actions implement map abstractions', () {
+      expect(GoogleMaps.view(coordinate: coordinate), isA<MapViewAction>());
+      expect(GoogleMaps.search(query: 'Central Park'), isA<MapSearchAction>());
+      expect(GoogleMaps.directions(destination: 'Central Park'), isA<MapDirectionsAction>());
+      expect(GoogleMaps.directionsWithCoords(destination: coordinate), isA<MapDirectionsWithCoordsAction>());
+    });
+
+    test('Apple Maps actions implement map abstractions', () {
+      expect(AppleMaps.view(coordinate: coordinate), isA<MapViewAction>());
+      expect(AppleMaps.search(query: 'Central Park'), isA<MapSearchAction>());
+      expect(AppleMaps.directions(destination: 'Central Park'), isA<MapDirectionsAction>());
+      expect(AppleMaps.directionsWithCoords(destination: coordinate), isA<MapDirectionsWithCoordsAction>());
+    });
+
+    test('Waze actions implement map abstractions', () {
+      expect(Waze.view(coordinate: coordinate), isA<MapViewAction>());
+      expect(Waze.search(query: 'Central Park'), isA<MapSearchAction>());
+      expect(Waze.directions(destination: 'Central Park'), isA<MapDirectionsAction>());
+      expect(Waze.directionsWithCoords(destination: coordinate), isA<MapDirectionsWithCoordsAction>());
+    });
+
+    test('Sygic actions implement supported map abstractions', () {
+      expect(Sygic.view(coordinate: coordinate), isA<MapViewAction>());
+      expect(Sygic.directionsWithCoords(destination: coordinate), isA<MapDirectionsWithCoordsAction>());
+    });
+  });
+}

--- a/test/src/core/deeplink_x_test.dart
+++ b/test/src/core/deeplink_x_test.dart
@@ -312,4 +312,92 @@ void main() {
       verifyNever(() => mockLauncherUtil.launchUrl(any()));
     });
   });
+
+  group('map action launchers', () {
+    const firstCoordinate = Coordinate(latitude: 1, longitude: 2);
+    const secondCoordinate = Coordinate(latitude: 3, longitude: 4);
+
+    test('launchMapViewAction tries later native actions before fallback', () async {
+      final first = Waze.view(
+        coordinate: firstCoordinate,
+        fallbackToStore: true,
+      );
+      final second = Waze.view(coordinate: secondCoordinate);
+
+      when(() => mockLauncherUtil.launchUrl(first.universalLink)).thenAnswer((final _) async => false);
+      when(() => mockLauncherUtil.launchUrl(second.universalLink)).thenAnswer((final _) async => true);
+
+      final result = await deeplinkX.launchMapViewAction(actions: [first, second]);
+
+      expect(result, isTrue);
+      verify(() => mockLauncherUtil.launchUrl(first.universalLink)).called(1);
+      verify(() => mockLauncherUtil.launchUrl(second.universalLink)).called(1);
+    });
+
+    test('launchMapViewAction falls back after all native actions fail', () async {
+      final first = Waze.view(coordinate: firstCoordinate);
+      final second = Waze.view(coordinate: secondCoordinate);
+      var firstLaunchCount = 0;
+
+      when(() => mockLauncherUtil.launchUrl(any())).thenAnswer((final _) async => false);
+      when(() => mockLauncherUtil.launchUrl(first.universalLink)).thenAnswer((final _) async {
+        firstLaunchCount += 1;
+        return firstLaunchCount == 2;
+      });
+      when(() => mockLauncherUtil.launchUrl(second.universalLink)).thenAnswer((final _) async => false);
+
+      final result = await deeplinkX.launchMapViewAction(actions: [first, second]);
+
+      expect(result, isTrue);
+      verifyInOrder([
+        () => mockLauncherUtil.launchUrl(first.universalLink),
+        () => mockLauncherUtil.launchUrl(second.universalLink),
+        () => mockLauncherUtil.launchUrl(first.universalLink),
+      ]);
+    });
+
+    test('launchMapViewAction respects disableFallback', () async {
+      final first = Waze.view(coordinate: firstCoordinate);
+      final second = Waze.view(coordinate: secondCoordinate);
+
+      when(() => mockLauncherUtil.launchUrl(any())).thenAnswer((final _) async => false);
+
+      final result = await deeplinkX.launchMapViewAction(
+        actions: [first, second],
+        disableFallback: true,
+      );
+
+      expect(result, isFalse);
+      verify(() => mockLauncherUtil.launchUrl(first.universalLink)).called(1);
+      verify(() => mockLauncherUtil.launchUrl(second.universalLink)).called(1);
+    });
+
+    test('launchMapSearchAction returns false for empty actions', () async {
+      final result = await deeplinkX.launchMapSearchAction(actions: []);
+
+      expect(result, isFalse);
+      verifyNever(() => mockLauncherUtil.isAppInstalled(any()));
+      verifyNever(() => mockLauncherUtil.launchUrl(any()));
+    });
+
+    test('map launcher methods accept each supported action type', () async {
+      final viewResult = await deeplinkX.launchMapViewAction(
+        actions: [Waze.view(coordinate: firstCoordinate)],
+      );
+      final searchResult = await deeplinkX.launchMapSearchAction(
+        actions: [Waze.search(query: 'Central Park')],
+      );
+      final directionsResult = await deeplinkX.launchMapDirectionsAction(
+        actions: [Waze.directions(destination: 'Central Park')],
+      );
+      final coordsResult = await deeplinkX.launchMapDirectionsWithCoordsAction(
+        actions: [Waze.directionsWithCoords(destination: firstCoordinate)],
+      );
+
+      expect(viewResult, isTrue);
+      expect(searchResult, isTrue);
+      expect(directionsResult, isTrue);
+      expect(coordsResult, isTrue);
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Adds typed map action abstractions and launch utilities for navigation provider fallback, then documents the new release surface.

## Changes

- Add `MapAppAction`, `MapViewAction`, `MapSearchAction`, `MapDirectionsAction`, and `MapDirectionsWithCoordsAction`.
- Wire Google Maps, Apple Maps, Waze, and Sygic actions into the relevant map abstractions.
- Add `DeeplinkX` map launch utility methods for view, search, directions, and coordinate directions flows.
- Update README, AGENTS guidance, changelog, version, and example lockfile for `1.3.0`.
- Add public API, provider conformance, and launcher behavior tests.

## Validation

- `dart format .`
- `flutter analyze`
- `flutter test --coverage`
- Coverage: `100.00% (1032/1032 lines)`
- `git diff --check`