### PR TITLE
[codex] Prepare 1.3.1+1 release docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.3.1+1
+
+* Refined README and API guidance for store redirects, clarifying that `redirectToStore` routes users to a configured target app's platform-specific store listing for installs, updates, promotions, or ad landing flows.
+* Added a promoted app/ad CTA `redirectToStore` example with supported tracking and referrer parameters.
+* Improved map provider fallback documentation to better explain declaring one navigation action and letting DeeplinkX launch the first installed provider.
+* Updated README tables and examples for clearer supported action, platform configuration, documentation, and `url_launcher` comparison sections.
+* Updated package metadata in `pubspec.yaml`, including homepage, documentation URL, topics, screenshots, and minimum Flutter SDK.
+
 ## 1.3.1
 
 * Restructured README for better first-read flow:

--- a/README.md
+++ b/README.md
@@ -28,30 +28,28 @@
 
 ## Table of Contents
 
-- [DeeplinkX](#deeplinkx)
-  - [Table of Contents](#table-of-contents)
-  - [Features](#features)
-  - [Demo](#demo)
-  - [Install](#install)
-  - [Quick Start](#quick-start)
-  - [Core Concepts](#core-concepts)
-    - [The three-tier fallback system](#the-three-tier-fallback-system)
-    - [Why custom schemes instead of universal links?](#why-custom-schemes-instead-of-universal-links)
-  - [Recipes](#recipes)
-    - [1. Launch an app action](#1-launch-an-app-action)
-    - [2. Launch an app](#2-launch-an-app)
-    - [3. Check if an app is installed](#3-check-if-an-app-is-installed)
-    - [4. Redirect to an app store](#4-redirect-to-an-app-store)
-    - [5. Map provider fallback](#5-map-provider-fallback)
-  - [Supported Apps and Actions](#supported-apps-and-actions)
-  - [Platform Configuration](#platform-configuration)
-  - [Why Custom Schemes Instead of Universal Links?](#why-custom-schemes-instead-of-universal-links-1)
-  - [DeeplinkX vs `url_launcher`](#deeplinkx-vs-url_launcher)
-  - [Missing an App?](#missing-an-app)
-  - [Documentation](#documentation)
-  - [Contributing](#contributing)
-  - [Feedback](#feedback)
-  - [License](#license)
+- [Features](#features)
+- [Demo](#demo)
+- [Install](#install)
+- [Quick Start](#quick-start)
+- [Core Concepts](#core-concepts)
+  - [The three-tier fallback system](#the-three-tier-fallback-system)
+  - [Why custom schemes instead of universal links?](#why-custom-schemes-instead-of-universal-links)
+- [Recipes](#recipes)
+  - [1. Launch an app action](#1-launch-an-app-action)
+  - [2. Launch an app](#2-launch-an-app)
+  - [3. Check if an app is installed](#3-check-if-an-app-is-installed)
+  - [4. Redirect to an app store](#4-redirect-to-an-app-store)
+  - [5. Map provider fallback](#5-map-provider-fallback)
+- [Supported Apps and Actions](#supported-apps-and-actions)
+- [Platform Configuration](#platform-configuration)
+- [Why Custom Schemes Instead of Universal Links?](#why-custom-schemes-instead-of-universal-links-1)
+- [DeeplinkX vs `url_launcher`](#deeplinkx-vs-url_launcher)
+- [Missing an App?](#missing-an-app)
+- [Documentation](#documentation)
+- [Contributing](#contributing)
+- [Feedback](#feedback)
+- [License](#license)
 
 ---
 
@@ -60,8 +58,8 @@
 - **Typed API** — launch any supported app or in-app action with strongly-typed Dart calls; no URL string maintenance.
 - **Smart fallback** — automatically redirects to the app store or a web URL when the target app is not installed.
 - **Installation check** — query whether any supported app is present on the device before attempting a launch.
-- **Store redirect** — send users to the correct store for their platform (iOS App Store, Google Play, Huawei AppGallery, and more).
-- **Map provider fallback** — try navigation apps in your preferred order; the first installed one wins.
+- **Store redirect** — send users to the correct store listing for any app you configure, including your own app, promoted apps, or ad landing pages, without detecting the platform manually.
+- **Map provider fallback** — declare a navigation action once (view, search, directions); DeeplinkX checks which apps are installed and opens the first available one automatically.
 - **Cross-platform** — works on iOS, Android, macOS, Windows, Linux, and Web from a single package.
 - **7 supported stores** — iOS App Store, Mac App Store, Microsoft Store, Google Play Store, Huawei AppGallery, Cafe Bazaar, Myket.
 - **15 supported apps** — Facebook, Instagram, LinkedIn, WhatsApp, Telegram, Twitter, YouTube, TikTok, Pinterest, Zoom, Slack, Google Maps, Waze, Apple Maps, Sygic.
@@ -216,28 +214,58 @@ if (isInstalled) {
 
 ### 4. Redirect to an app store
 
-Send users to the correct store for their platform. DeeplinkX picks the matching entry automatically:
+Use this to send users to the correct store page for any app you configure. That can be your own app for install or update flows, or another app's listing from a promotion, recommendation, or ad. You declare each platform-specific listing, and DeeplinkX opens the one that matches the user's platform automatically. No platform detection needed.
+
+```dart
+// Add every store listing you want to support.
+// DeeplinkX opens the one that matches the current platform.
+await deeplinkX.redirectToStore(
+  storeActions: [
+    IOSAppStore.openAppPage(appId: 'TARGET_APP_ID', appName: 'target-app'),
+    MacAppStore.openAppPage(appId: 'TARGET_APP_ID', appName: 'target-app'),
+    PlayStore.openAppPage(packageName: 'com.target.app'),
+    MicrosoftStore.openAppPage(productId: 'YOUR_PRODUCT_ID'),
+    HuaweiAppGalleryStore.openAppPage(
+      packageName: 'com.target.app',
+      appId: 'YOUR_HUAWEI_APP_ID',
+    ),
+    CafeBazaarStore.openAppPage(packageName: 'com.target.app'),
+    MyketStore.openAppPage(packageName: 'com.target.app'),
+  ],
+);
+```
+
+Common patterns include an "Update App" button, a promoted app card, or an ad call-to-action. When the user taps it on Android they land on Google Play, on iOS on the App Store, on Huawei devices on AppGallery — without a single `Platform.isAndroid` check in your code.
+
+For promoted apps or ad CTAs, pass tracking values on stores that support them:
 
 ```dart
 await deeplinkX.redirectToStore(
   storeActions: [
-    IOSAppStore.openAppPage(appId: '389801252', appName: 'instagram'),
-    PlayStore.openAppPage(packageName: 'com.instagram.android'),
-    HuaweiAppGalleryStore.openAppPage(
-      packageName: 'com.instagram.android',
-      appId: 'C101162369',
+    IOSAppStore.openAppPage(
+      appId: 'TARGET_APP_ID',
+      appName: 'target-app',
+      campaignToken: 'spring_sale',
+      providerToken: 'partner_network',
+      affiliateToken: 'affiliate_123',
+      uniqueOrigin: 'home_banner',
     ),
-    MacAppStore.openAppPage(appId: '1274495053', appName: 'instagram'),
-    MicrosoftStore.openAppPage(productId: '9nblggh5l9xt'),
-    CafeBazaarStore.openAppPage(packageName: 'com.instagram.android'),
-    MyketStore.openAppPage(packageName: 'com.instagram.android'),
+    PlayStore.openAppPage(
+      packageName: 'com.target.app',
+      referrer: 'utm_source=deeplink_x&utm_medium=ad&utm_campaign=spring_sale',
+    ),
+    HuaweiAppGalleryStore.openAppPage(
+      packageName: 'com.target.app',
+      appId: 'YOUR_HUAWEI_APP_ID',
+      referrer: 'utm_source=deeplink_x&utm_medium=ad&utm_campaign=spring_sale',
+    ),
   ],
 );
 ```
 
 ### 5. Map provider fallback
 
-Try navigation apps in priority order. DeeplinkX attempts each one natively and moves to the next if the app is not installed:
+Instead of checking which navigation app is installed and then deciding which one to call, you declare what you want to do and list the apps you want to support. DeeplinkX checks installation and opens the first available one. If none are installed, it falls back to the web URL when one exists.
 
 ```dart
 final deeplinkX = DeeplinkX();
@@ -284,41 +312,41 @@ await deeplinkX.launchMapDirectionsWithCoordsAction(
 );
 ```
 
-| Method | Supported apps |
-| --- | --- |
-| `launchMapViewAction` | Google Maps, Apple Maps, Waze, Sygic |
-| `launchMapSearchAction` | Google Maps, Apple Maps, Waze |
-| `launchMapDirectionsAction` | Google Maps, Apple Maps, Waze |
+| Method                                | Supported apps                       |
+| ------------------------------------- | ------------------------------------ |
+| `launchMapViewAction`                 | Google Maps, Apple Maps, Waze, Sygic |
+| `launchMapSearchAction`               | Google Maps, Apple Maps, Waze        |
+| `launchMapDirectionsAction`           | Google Maps, Apple Maps, Waze        |
 | `launchMapDirectionsWithCoordsAction` | Google Maps, Apple Maps, Waze, Sygic |
 
 ---
 
 ## Supported Apps and Actions
 
-| Category | App | Actions |
-| --- | --- | --- |
-| **Stores** | iOS App Store | Open app page, rate app |
-| | Mac App Store | Open app page, rate app |
-| | Microsoft Store | Open app page, rate app |
-| | Google Play Store | Open app page |
-| | Huawei AppGallery | Open app page |
-| | Cafe Bazaar | Open app page |
-| | Myket | Open app page, rate app |
-| **Social** | Telegram | Open profile by username, open profile by phone number, send message |
-| | Instagram | Open profile by username |
-| | WhatsApp | Chat with phone number, share text content |
-| | Facebook | Open profile by ID, open profile by username, open page, open group, open event |
-| | YouTube | Open video, open channel, open playlist, search |
-| | Twitter | Open profile by username, open tweet by ID, search |
-| | Pinterest | Open profile by username, open pin, open board by ID, search |
-| | TikTok | Open profile by username, open video, open tag |
-| | Zoom | Join meeting by ID |
-| | Slack | Open team, open channel, open user |
-| | LinkedIn | Open profile page, open company page |
-| **Navigation** | Google Maps | View map, search location, directions, directions with coordinates |
-| | Apple Maps | View map, search location, directions, directions with coordinates |
-| | Waze | View map, search, directions, directions with coordinates |
-| | Sygic | View map, directions with coordinates |
+| Category       | App               | Actions                                                                         |
+| -------------- | ----------------- | ------------------------------------------------------------------------------- |
+| **Stores**     | iOS App Store     | Open app page, rate app                                                         |
+|                | Mac App Store     | Open app page, rate app                                                         |
+|                | Microsoft Store   | Open app page, rate app                                                         |
+|                | Google Play Store | Open app page                                                                   |
+|                | Huawei AppGallery | Open app page                                                                   |
+|                | Cafe Bazaar       | Open app page                                                                   |
+|                | Myket             | Open app page, rate app                                                         |
+| **Social**     | Telegram          | Open profile by username, open profile by phone number, send message            |
+|                | Instagram         | Open profile by username                                                        |
+|                | WhatsApp          | Chat with phone number, share text content                                      |
+|                | Facebook          | Open profile by ID, open profile by username, open page, open group, open event |
+|                | YouTube           | Open video, open channel, open playlist, search                                 |
+|                | Twitter           | Open profile by username, open tweet by ID, search                              |
+|                | Pinterest         | Open profile by username, open pin, open board by ID, search                    |
+|                | TikTok            | Open profile by username, open video, open tag                                  |
+|                | Zoom              | Join meeting by ID                                                              |
+|                | Slack             | Open team, open channel, open user                                              |
+|                | LinkedIn          | Open profile page, open company page                                            |
+| **Navigation** | Google Maps       | View map, search location, directions, directions with coordinates              |
+|                | Apple Maps        | View map, search location, directions, directions with coordinates              |
+|                | Waze              | View map, search, directions, directions with coordinates                       |
+|                | Sygic             | View map, directions with coordinates                                           |
 
 ---
 
@@ -326,11 +354,11 @@ await deeplinkX.launchMapDirectionsWithCoordsAction(
 
 Some platforms require you to declare URL schemes or package visibility before the OS allows installation checks.
 
-| Platform | File |
-| --- | --- |
-| iOS | `ios/Runner/Info.plist` |
-| Android | `android/app/src/main/AndroidManifest.xml` |
-| macOS | `macos/Runner/Info.plist` |
+| Platform | File                                       |
+| -------- | ------------------------------------------ |
+| iOS      | `ios/Runner/Info.plist`                    |
+| Android  | `android/app/src/main/AndroidManifest.xml` |
+| macOS    | `macos/Runner/Info.plist`                  |
 
 Windows, Linux, and Web do not require additional configuration.
 
@@ -376,17 +404,17 @@ DeeplinkX prefers custom URL schemes, App Links, and Android Intents over plain 
 
 `url_launcher` is a general-purpose URL launcher. DeeplinkX is purpose-built for external app deeplinks and goes further in every dimension that matters for that use case:
 
-| | DeeplinkX | `url_launcher` |
-| --- | --- | --- |
-| **Typed API for popular apps** | ✅ 15 apps, no URL maintenance | ❌ Raw URLs only |
-| **Automatic store / web fallback** | ✅ Built in | ❌ Manual implementation required |
-| **Installation check** | ✅ `isAppInstalled()` | ⚠️ `canLaunchUrl()` — unreliable for HTTPS schemes |
-| **Android Intent support** | ✅ Advanced intent options | ⚠️ Basic intent launching only |
-| **macOS custom scheme check** | ✅ Supported | ❌ Not supported |
-| **Map provider fallback** | ✅ Try multiple apps in order | ❌ Not available |
-| **Store redirect utility** | ✅ Per-platform store routing | ❌ Not available |
+|                                    | DeeplinkX                     | `url_launcher`                                    |
+| ---------------------------------- | ----------------------------- | ------------------------------------------------- |
+| **Typed API for popular apps**     | ✅ 15 apps, no URL maintenance | ❌ Raw URLs only                                   |
+| **Automatic store / web fallback** | ✅ Built in                    | ❌ Manual implementation required                  |
+| **Installation check**             | ✅ `isAppInstalled()`          | ⚠️ `canLaunchUrl()` — unreliable for HTTPS schemes |
+| **Android Intent support**         | ✅ Advanced intent options     | ⚠️ Basic intent launching only                     |
+| **macOS custom scheme check**      | ✅ Supported                   | ❌ Not supported                                   |
+| **Map provider fallback**          | ✅ Try multiple apps in order  | ❌ Not available                                   |
+| **Store listing redirect**         | ✅ One call, all platforms     | ❌ Not available                                   |
 
-In practice: a store redirect with `url_launcher` requires you to detect the platform, look up each store URL format, handle edge cases for Huawei devices, and write that logic for every app in your project. DeeplinkX handles all of it with one method call.
+In practice: redirecting users to a target app's store page with `url_launcher` requires you to detect the platform, look up each store URL format, handle edge cases for Huawei devices, and wire that logic in every place you need it. DeeplinkX handles all of it with one `redirectToStore` call — you just supply the app IDs for each store once.
 
 ---
 
@@ -402,35 +430,35 @@ Per-app documentation covering URL schemes, required configuration, and fallback
 
 **Stores**
 
-| Store | Link |
-| --- | --- |
-| iOS App Store | [ios_app_store.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/stores/ios_app_store.md) |
-| Mac App Store | [mac_app_store.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/stores/mac_app_store.md) |
-| Microsoft Store | [microsoft_store.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/stores/microsoft_store.md) |
-| Google Play Store | [play_store.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/stores/play_store.md) |
+| Store             | Link                                                                                                                          |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| iOS App Store     | [ios_app_store.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/stores/ios_app_store.md)                       |
+| Mac App Store     | [mac_app_store.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/stores/mac_app_store.md)                       |
+| Microsoft Store   | [microsoft_store.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/stores/microsoft_store.md)                   |
+| Google Play Store | [play_store.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/stores/play_store.md)                             |
 | Huawei AppGallery | [huawei_app_gallery_store.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/stores/huawei_app_gallery_store.md) |
-| Cafe Bazaar | [cafe_bazaar_store.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/stores/cafe_bazaar_store.md) |
-| Myket | [myket_store.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/stores/myket_store.md) |
+| Cafe Bazaar       | [cafe_bazaar_store.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/stores/cafe_bazaar_store.md)               |
+| Myket             | [myket_store.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/stores/myket_store.md)                           |
 
 **Apps**
 
-| App | Link |
-| --- | --- |
-| Facebook | [facebook.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/facebook.md) |
-| Instagram | [instagram.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/instagram.md) |
-| Telegram | [telegram.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/telegram.md) |
-| WhatsApp | [whatsapp.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/whatsapp.md) |
-| LinkedIn | [linkedin.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/linkedin.md) |
-| YouTube | [youtube.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/youtube.md) |
-| Twitter | [twitter.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/twitter.md) |
-| Pinterest | [pinterest.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/pinterest.md) |
-| TikTok | [tiktok.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/tiktok.md) |
-| Zoom | [zoom.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/zoom.md) |
-| Slack | [slack.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/slack.md) |
+| App         | Link                                                                                         |
+| ----------- | -------------------------------------------------------------------------------------------- |
+| Facebook    | [facebook.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/facebook.md)       |
+| Instagram   | [instagram.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/instagram.md)     |
+| Telegram    | [telegram.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/telegram.md)       |
+| WhatsApp    | [whatsapp.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/whatsapp.md)       |
+| LinkedIn    | [linkedin.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/linkedin.md)       |
+| YouTube     | [youtube.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/youtube.md)         |
+| Twitter     | [twitter.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/twitter.md)         |
+| Pinterest   | [pinterest.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/pinterest.md)     |
+| TikTok      | [tiktok.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/tiktok.md)           |
+| Zoom        | [zoom.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/zoom.md)               |
+| Slack       | [slack.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/slack.md)             |
 | Google Maps | [google_maps.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/google_maps.md) |
-| Waze | [waze.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/waze.md) |
-| Apple Maps | [apple_maps.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/apple_maps.md) |
-| Sygic | [sygic.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/sygic.md) |
+| Waze        | [waze.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/waze.md)               |
+| Apple Maps  | [apple_maps.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/apple_maps.md)   |
+| Sygic       | [sygic.md](https://github.com/DeeplinkX/DeeplinkX/blob/master/doc/apps/sygic.md)             |
 
 Full API reference is on [pub.dev](https://pub.dev/documentation/deeplink_x/latest/).
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -71,7 +71,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.3.1"
+    version: "1.3.1+1"
   deeplink_x_android:
     dependency: transitive
     description:

--- a/lib/src/core/deeplink_x.dart
+++ b/lib/src/core/deeplink_x.dart
@@ -146,10 +146,11 @@ class DeeplinkX {
     return _launcherUtil.launchUrl(app.website);
   }
 
-  /// Redirects the user to the appropriate app store based on the current platform.
+  /// Redirects the user to the matching app store page based on the current platform.
   ///
-  /// This method is particularly useful when your app has a new update and you want
-  /// to navigate users to the relevant app store to update the application.
+  /// This method is useful when you want to send users to a platform-specific
+  /// listing for any app you configure, such as your own app update page, a
+  /// promoted app, or an ad landing page.
   ///
   /// The method attempts to launch each store action that matches the current platform
   /// in the order they are provided. It stops and returns `true` as soon as one

--- a/lib/src/core/interfaces/store_open_app_page_action_interface.dart
+++ b/lib/src/core/interfaces/store_open_app_page_action_interface.dart
@@ -3,7 +3,6 @@ import 'package:deeplink_x/src/core/interfaces/interfaces.dart';
 /// Represents an action to open an app's page in an app store.
 ///
 /// This interface combines [StoreApp] and [AppAction] to define actions
-/// that open specific app pages within app stores. This is typically used
-/// to redirect users to download or update an app when it's not installed
-/// or when a fallback is needed.
+/// that open specific app pages within app stores. This can be used to
+/// redirect users to download, update, promote, or advertise a target app.
 abstract class StoreOpenAppPageAction extends StoreApp implements AppAction {}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,21 +1,35 @@
 name: deeplink_x
 description: Easy to use Flutter plugin for type-safe external deeplink launching with built-in smart fallback, supporting app stores and popular apps.
-version: 1.3.1
-
+version: 1.3.1+1
+homepage: https://github.com/DeepLinkX/DeeplinkX
 repository: https://github.com/DeepLinkX/DeeplinkX
 issue_tracker: https://github.com/DeepLinkX/DeeplinkX/issues
-documentation: https://pub.dev/documentation/deeplink_x/latest/deeplink_x/
+documentation: https://pub.dev/documentation/deeplink_x/latest/
 
 topics:
-  - app-links
+  - deeplink
   - external-deeplink
-  - universal-links
+  - app-links
   - custom-url-schemes
   - open-store
 
+screenshots:
+  - description: Opening an Instagram profile via deeplink
+    path: images/previews/01_instagram_open_profile.gif
+  - description: Opening a Telegram profile via deeplink
+    path: images/previews/02_telegram_open_profile.gif
+  - description: Opening the Facebook app via deeplink
+    path: images/previews/03_facebook_open_app.gif
+  - description: Opening a YouTube video via deeplink
+    path: images/previews/04_youtube_open_video.gif
+  - description: Facebook profile falling back to web when app is not installed
+    path: images/previews/05_facebook_open_web_profile.gif
+  - description: Opening an app page in the iOS App Store
+    path: images/previews/06_ios_app_store_open_page.gif
+
 environment:
-  sdk: ">=3.1.0 <4.0.0"
-  flutter: ">=3.12.0"
+  sdk: '>=3.1.0 <4.0.0'
+  flutter: '>=3.13.0'
 
 dependencies:
   flutter:
@@ -23,17 +37,17 @@ dependencies:
   deeplink_x_platform_interface: ^0.1.0
   deeplink_x_android: ^1.0.0
   deeplink_x_ios: ^0.1.0
-  deeplink_x_linux: ^0.1.0
   deeplink_x_macos: ^0.2.0
-  deeplink_x_web: ^0.1.0
+  deeplink_x_linux: ^0.1.0
   deeplink_x_windows: ^0.1.0
+  deeplink_x_web: ^0.1.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0
-  mocktail: ^1.0.4
-  plugin_platform_interface: ^2.1.8
+  mocktail: ^1.0.0
+  plugin_platform_interface: ^2.0.0
 
 flutter:
   plugin:
@@ -42,11 +56,11 @@ flutter:
         default_package: deeplink_x_android
       ios:
         default_package: deeplink_x_ios
-      linux:
-        default_package: deeplink_x_linux
       macos:
         default_package: deeplink_x_macos
-      web:
-        default_package: deeplink_x_web
+      linux:
+        default_package: deeplink_x_linux
       windows:
         default_package: deeplink_x_windows
+      web:
+        default_package: deeplink_x_web


### PR DESCRIPTION
## Summary

Prepare the `1.3.1+1` release metadata and documentation.

## Changes

- Bump `deeplink_x` to `1.3.1+1` and update the example lockfile.
- Add a `1.3.1+1` changelog entry for README/package metadata refinements.
- Clarify `redirectToStore` docs so it covers any configured target app listing, including promoted apps and ad landing flows.
- Add a promoted app/ad CTA README example using supported tracking and referrer parameters.
- Remove self-referential README table-of-contents entries.

## Validation

- `dart format .`
- `flutter analyze`
- `flutter test`
- `flutter pub publish --dry-run`