### PR TITLE
release: prepare 1.3.5+1 with pub readiness checks

### DIFF
--- a/.github/workflows/pub-readiness.yml
+++ b/.github/workflows/pub-readiness.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Flutter pub get
         run: flutter pub get
 
+      - name: Install WebP tools
+        run: sudo apt-get install -y webp
+
       - name: Activate Pana
         run: dart pub global activate pana
 

--- a/.github/workflows/pub-readiness.yml
+++ b/.github/workflows/pub-readiness.yml
@@ -1,0 +1,51 @@
+name: Pub Readiness
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  FLUTTER_VERSION: ${{ vars.FLUTTER_VERSION || '3.41.1' }}
+  FLUTTER_CHANNEL: ${{ vars.FLUTTER_CHANNEL || 'stable' }}
+
+jobs:
+  pub-readiness:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: ${{ env.FLUTTER_CHANNEL }}
+          cache: true
+          pub-cache: true
+          cache-key: "deeplinkx-pub-readiness-flutter-:os:-:channel:-:version:-:arch:-:hash:"
+          pub-cache-key: "deeplinkx-pub-readiness-flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
+
+      - name: Flutter version
+        run: flutter --version
+
+      - name: Flutter pub get
+        run: flutter pub get
+
+      - name: Activate Pana
+        run: dart pub global activate pana
+
+      - name: Check Pana score
+        run: dart pub global run pana --exit-code-threshold 0 .
+
+      - name: Publish dry run
+        run: flutter pub publish --dry-run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.5+1
+
+* Added a Pub Readiness GitHub Actions workflow that enforces a full Pana score and runs `flutter pub publish --dry-run`.
+
 ## 1.3.5
 
 * Added Moovit app with the following actions:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -71,7 +71,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.3.5"
+    version: "1.3.5+1"
   deeplink_x_android:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: deeplink_x
 description: Type-safe Flutter deeplinks for WhatsApp, Telegram, Instagram, YouTube, Google Maps, Waze and app stores, with automatic store and web fallback.
-version: 1.3.5
+version: 1.3.5+1
 homepage: https://github.com/DeepLinkX/DeeplinkX
 repository: https://github.com/DeepLinkX/DeeplinkX
 issue_tracker: https://github.com/DeepLinkX/DeeplinkX/issues


### PR DESCRIPTION
## Summary
- add a Pub Readiness workflow that enforces a full Pana score and runs `flutter pub publish --dry-run`
- bump package metadata to `1.3.5+1`
- add a changelog entry and align the example lockfile path dependency

## Verification
- `dart format .`
- `flutter analyze`
- `flutter test`
- clean-copy `flutter pub publish --dry-run`
- `dart pub global run pana --exit-code-threshold 0 .` (`160/160`)
- `git diff --check`