### PR TITLE
release: prepare 1.3.5+2 pub publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,40 @@
+name: Publish to pub.dev
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  verify-tag-on-master:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify tag commit is on master
+        run: |
+          git fetch origin master
+          tag_commit="$(git rev-parse "${GITHUB_REF}^{commit}")"
+          if ! git merge-base --is-ancestor "$tag_commit" origin/master; then
+            echo "Tag commit $tag_commit is not contained in origin/master." >&2
+            exit 1
+          fi
+
+  publish:
+    needs: verify-tag-on-master
+    permissions:
+      contents: read
+      id-token: write
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    with:
+      environment: pub.dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.5+2
+
+* Added tag-based GitHub Actions publishing to pub.dev.
+
 ## 1.3.5+1
 
 * Added a Pub Readiness GitHub Actions workflow that enforces a full Pana score and runs `flutter pub publish --dry-run`.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -71,7 +71,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.3.5+1"
+    version: "1.3.5+2"
   deeplink_x_android:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: deeplink_x
 description: Type-safe Flutter deeplinks for WhatsApp, Telegram, Instagram, YouTube, Google Maps, Waze and app stores, with automatic store and web fallback.
-version: 1.3.5+1
+version: 1.3.5+2
 homepage: https://github.com/DeepLinkX/DeeplinkX
 repository: https://github.com/DeepLinkX/DeeplinkX
 issue_tracker: https://github.com/DeepLinkX/DeeplinkX/issues


### PR DESCRIPTION
## Summary
- bump package metadata to `1.3.5+2`
- add tag-triggered pub.dev publishing via Dart trusted publishing/OIDC
- guard publishing so tags must point to commits contained in `origin/master`

## Pub.dev settings
- Repository: `DeepLinkX/DeeplinkX`
- Tag pattern: `v{{version}}`
- Enable publishing from `push` events
- Do not enable `workflow_dispatch` events
- Require GitHub Actions environment: `pub.dev`

## Verification
- `dart format .`
- `flutter analyze`
- `flutter test`
- clean-copy `flutter pub publish --dry-run` (`Package has 0 warnings and 1 hint`)
- `dart pub global run pana --exit-code-threshold 0 .` (`160/160`)
- `git diff --check`

## Release after merge
After this PR is merged to `master`, publish by creating and pushing `v1.3.5+2` from the merged master commit. The tag-triggered workflow will run the reusable Dart publish workflow.