### PR TITLE
fix: audit deep-link actions and fallbacks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,10 +43,14 @@ When introducing a new navigation app (e.g. Maps providers), follow this checkli
 3. **Example App**
    - Provide a sample page in `example/lib/pages/` that demonstrates all supported actions.
    - Add the page to the grid/list in `example/lib/home.dart` and include required assets.
+   - Add every required app and store scheme to `example/ios/Runner/Info.plist` under `LSApplicationQueriesSchemes`.
+   - Add every required package and intent visibility query to `example/android/app/src/main/AndroidManifest.xml`.
+   - Avoid duplicate platform entries and verify both example configuration files after updating them.
 
 4. **Testing**
    - Add unit tests under `test/src/apps/` covering store actions, app links, and fallbacks.
    - Update the integration/coverage checks in `test/deeplink_x_test.dart` when necessary (e.g. exposed API lists).
+   - When `map_launcher` supports the provider, record the checked release and date, compare its overlapping marker and directions behavior, and document intentional differences. Provider documentation and device results remain authoritative.
    - Run `dart format .`, `flutter analyze`, and `flutter test` (via FVM if required).
 
 5. **Release Artifacts**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+* Added verified Threads search and topic-tag actions with native Android/iOS links and web fallbacks.
+* Prevented combined intent/app-link actions from retrying the same app link.
+* Audited Amap, Baidu Maps, 2GIS, Yandex Maps, Moovit, and Neshan URI contracts against current provider documentation and physical Android behavior.
+* Corrected provider-specific route modes, marker defaults, source/partner identifiers, validation, Android URI variants, and canonical web fallbacks.
+* Added the audited app queries to the example iOS and Android projects and documented Telegram's Android package-visibility setup.
+
 ## 1.3.8
 
 * Added Yandex Maps app support:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 1.3.9
 
 * Added verified Threads search and topic-tag actions with native Android/iOS links and web fallbacks.
 * Prevented combined intent/app-link actions from retrying the same app link.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,32 @@ On iOS, declare the schemes you query in `ios/Runner/Info.plist` (each app's [do
 </array>
 ```
 
+On Android, add package and intent visibility declarations directly under
+`<manifest>`, alongside `<application>`, in
+`android/app/src/main/AndroidManifest.xml`:
+
+```xml
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <queries>
+        <package android:name="org.telegram.messenger" />
+        <package android:name="com.android.vending" />
+        <package android:name="com.huawei.appmarket" />
+
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="https" />
+        </intent>
+    </queries>
+
+    <application ...>
+        <!-- ... -->
+    </application>
+</manifest>
+```
+
+This placement follows Android's
+[package visibility guidance](https://developer.android.com/training/package-visibility/declaring).
+
 That's the whole flow — DeeplinkX resolves the platform, checks installation, and handles the fallback.
 
 ## Demo
@@ -312,7 +338,7 @@ await deeplinkX.launchMapDirectionsWithCoordsAction(
 |                | Facebook          | Open profile by ID, open profile by username, open page, open group, open event |
 |                | YouTube           | Open video, open channel, open playlist, search                                 |
 |                | Twitter           | Open profile by username, open tweet by ID, search                              |
-|                | Threads           | Open profile by username, open post, open comments, create post                 |
+|                | Threads           | Open profile by username, open post, open comments, create post, search, open topic tag |
 |                | Pinterest         | Open profile by username, open pin, open board by ID, search                    |
 |                | TikTok            | Open profile by username, open video, open tag                                  |
 |                | Zoom              | Join meeting by ID                                                              |

--- a/doc/apps/2gis.md
+++ b/doc/apps/2gis.md
@@ -4,8 +4,7 @@ DeeplinkX supports the 2GIS custom URI scheme on iOS and Android for opening the
 
 ## References
 
-- Map Launcher marker implementation: <https://github.com/mattermoran/map_launcher/blob/master/lib/src/marker_url.dart>
-- Map Launcher directions implementation: <https://github.com/mattermoran/map_launcher/blob/master/lib/src/directions_url.dart>
+- 2GIS navigation deeplink documentation: <https://help.2gis.com/question/developers-launching-2gis-navigation-using-deeplink>
 
 ## Available Actions
 
@@ -66,8 +65,16 @@ Allow querying the package in `android/app/src/main/AndroidManifest.xml`:
 
 - iOS view map: `dgis://2gis.ru/geo/{longitude},{latitude}`
 - Android view map intent data: `dgis://2gis.ru/routeSearch/rsType/car/to/{longitude},{latitude}`
-- Directions with coordinates: `dgis://2gis.ru/routeSearch/rsType/{auto|car|bus|pedestrian}/from/{originLongitude},{originLatitude}/to/{destinationLongitude},{destinationLatitude}`
-- Destination-only directions: `dgis://2gis.ru/routeSearch/rsType/{auto|car|bus|pedestrian}/to/{destinationLongitude},{destinationLatitude}`
+- Directions with coordinates: `dgis://2gis.ru/routeSearch/rsType/{car|ctx|pedestrian}/from/{originLongitude},{originLatitude}/to/{destinationLongitude},{destinationLatitude}`
+- Destination-only directions: `dgis://2gis.ru/routeSearch/rsType/{car|ctx|pedestrian}/to/{destinationLongitude},{destinationLatitude}`
+
+`TwoGisTravelMode.auto` remains as a deprecated source-compatible alias but
+emits the supported `car` value. Transit custom links and web fallbacks emit
+the provider-documented `ctx`. The package-targeted Android intent uses `bus`,
+which is the value accepted by the current Android app for selecting public
+transport.
+Longitude-latitude ordering and Android's marker-to-route behavior remain
+compatible with existing integrations.
 
 ## Fallback Behavior
 

--- a/doc/apps/amap.md
+++ b/doc/apps/amap.md
@@ -33,6 +33,7 @@ await deeplinkX.launchAction(
   Amap.view(
     coordinate: const Coordinate(latitude: 39.98848272, longitude: 116.47560823),
     title: 'Amap HQ',
+    sourceApplication: 'my_flutter_app',
     convertFromWgs84: true,
   ),
 );
@@ -116,8 +117,12 @@ Allow querying the Amap package in `android/app/src/main/AndroidManifest.xml`:
 - My location: `androidamap://mylocation?sourceApplication=deeplink_x`
 - View map: `androidamap://viewmap?sourceApplication=deeplink_x&poiname={title}&lat={lat}&lon={lon}&dev={0|1}`
 - Search: `androidamap://poi?sourceApplication=deeplink_x&keywords={query}&lat1={lat1}&lon1={lon1}&lat2={lat2}&lon2={lon2}&dev={0|1}`
-- Directions: `amapuri://route/plan/?sourceApplication=deeplink_x&dname={destination}&dev=0&t=0`
+- Directions: `androidamap://keywordNavi?sourceApplication=deeplink_x&keyword={destination}&style=2`
 - Directions with coordinates: `amapuri://route/plan/?sourceApplication=deeplink_x&slat={origin_lat}&slon={origin_lng}&sname={origin}&dlat={dest_lat}&dlon={dest_lng}&dname={destination}&dev={0|1}&t={mode}`
+
+`sourceApplication` is optional on every action and defaults to `deeplink_x`.
+Marker titles default to `Pin` when omitted. Text-only Android destinations use
+Amap's documented `keywordNavi` entry point.
 
 ## Fallback Behavior
 

--- a/doc/apps/baidu_maps.md
+++ b/doc/apps/baidu_maps.md
@@ -27,6 +27,7 @@ await deeplinkX.launchAction(
     content: 'Beijing landmark',
     zoom: 16,
     coordType: BaiduMapsCoordType.wgs84,
+    sourceApplication: 'my_flutter_app',
   ),
 );
 ```
@@ -104,12 +105,13 @@ await deeplinkX.launchAction(
 await deeplinkX.launchAction(
   BaiduMaps.navigate(
     destination: const Coordinate(latitude: 39.915, longitude: 116.404),
+    destinationTitle: 'Tiananmen',
     mode: BaiduMapsNavigationMode.walking,
   ),
 );
 ```
 
-## Map Launcher Interfaces
+## Shared Map Interfaces
 
 These actions implement shared map-launcher abstractions:
 
@@ -155,12 +157,23 @@ Add Baidu Maps to package visibility in `android/app/src/main/AndroidManifest.xm
 | ------------------ | --------------------------------------- |
 | View marker        | `baidumap://map/marker`                 |
 | Search             | `baidumap://map/place/search`           |
-| Nearby search      | `baidumap://map/place/nearby`           |
+| Nearby search      | Android `place/nearby`; iOS `nearbysearch` |
 | Transit line       | `baidumap://map/line`                   |
 | Directions         | `baidumap://map/direction`              |
 | Driving navigation | `baidumap://map/navi`                   |
 | Walking navigation | `baidumap://map/walknavi`               |
 | Riding navigation  | Android `bikenavi`, iOS `ridenavi`      |
+
+Every action accepts an optional `sourceApplication`, defaulting to
+`deeplink_x`; the generated `src` is prefixed with `andr.` or `ios.` for the
+target platform. Omitted marker text uses `Pin` and `Description`. Transit line
+lookups require a nonblank `region`, and iOS driving navigation accepts an
+optional `destinationTitle` for its required query label.
+
+DeeplinkX uses familiar marker defaults and Baidu's
+`name:...|latlng:...` route-point format while enforcing provider-required
+transit regions and distinct Android and iOS nearby-search paths and parameter
+names.
 
 ## Fallbacks
 

--- a/doc/apps/moovit.md
+++ b/doc/apps/moovit.md
@@ -4,7 +4,7 @@ DeeplinkX supports Moovit's `moovit` URI scheme so Flutter apps can open nearby 
 
 ## References
 
-- Map Launcher open-source implementation of the same URI scheme: <https://github.com/mattermoran/map_launcher/blob/master/lib/src/marker_url.dart>
+- Moovit deeplinking documentation: <https://moovit.com/developers/deeplinking/>
 - Moovit App Store listing: <https://apps.apple.com/us/app/moovit-bus-transit-tracker/id498477945>
 
 ## Available Actions
@@ -22,6 +22,7 @@ await deeplinkX.launchApp(Moovit.open());
 await deeplinkX.launchAction(
   Moovit.view(
     coordinate: const Coordinate(latitude: 40.7128, longitude: -74.0060),
+    partnerId: 'my_flutter_app',
   ),
 );
 ```
@@ -63,8 +64,11 @@ Allow querying the package in `android/app/src/main/AndroidManifest.xml`:
 
 ## URI Formats
 
-- View map: `moovit://nearby?lat={latitude}&lon={longitude}`
-- Directions: `moovit://directions?dest_lat={destinationLatitude}&dest_lon={destinationLongitude}&dest_name={destinationTitle}&orig_lat={originLatitude}&orig_lon={originLongitude}&orig_name={originTitle}`
+- View map: `moovit://nearby?lat={latitude}&lon={longitude}&partner_id={partnerId}`
+- Directions: `moovit://directions?dest_lat={destinationLatitude}&dest_lon={destinationLongitude}&dest_name={destinationTitle}&orig_lat={originLatitude}&orig_lon={originLongitude}&orig_name={originTitle}&partner_id={partnerId}`
+
+`partnerId` is optional and defaults to `deeplink_x`. DeeplinkX emits Moovit's
+documented `partner_id` on nearby and directions actions.
 
 ## Fallback Behavior
 

--- a/doc/apps/neshan.md
+++ b/doc/apps/neshan.md
@@ -4,9 +4,8 @@ DeeplinkX supports Neshan's native iOS `neshan` URI scheme and Android package-t
 
 ## References
 
-- Map Launcher open-source implementation of the same URI patterns: <https://github.com/mattermoran/map_launcher/blob/master/lib/src/marker_url.dart>
 - Neshan App Store listing: <https://apps.apple.com/us/app/neshan-map/id1548188093>
-- Neshan web map fallback: <https://nshn.ir>
+- Neshan web map fallback: <https://neshan.org/maps>
 
 ## Available Actions
 
@@ -63,16 +62,23 @@ Allow querying the package in `android/app/src/main/AndroidManifest.xml`:
 ## URI Formats
 
 - iOS view map: `neshan://?destination={latitude},{longitude}`
-- Android view map and web fallback: `https://nshn.ir?lat={latitude}&lng={longitude}`
+- Android package-targeted view map: `https://nshn.ir?lat={latitude}&lng={longitude}`
+- Web view fallback: `https://neshan.org/maps/share/{latitude},{longitude}`
 - iOS directions: `neshan://?origin={originLatitude},{originLongitude}&destination={destinationLatitude},{destinationLongitude}`
-- Android directions and web fallback: `https://nshn.ir/?origin={originLatitude},{originLongitude}&destination={destinationLatitude},{destinationLongitude}`
+- Android package-targeted directions: `https://nshn.ir/?origin={originLatitude},{originLongitude}&destination={destinationLatitude},{destinationLongitude}`
+- Web directions fallback: `https://neshan.org/maps`
 
 ## Fallback Behavior
 
 1. DeeplinkX opens the native app when installed.
 2. If the app is missing and `fallbackToStore` is `true`, we redirect to the appropriate store listing.
-3. Otherwise view and directions actions fall back to the matching `https://nshn.ir` web map URL.
+3. Otherwise view actions use Neshan's canonical share URL and directions open
+   the canonical web map.
 4. Set `disableFallback: true` when calling `launchAction` to skip both store and web fallbacks.
+
+The Android `nshn.ir` URI remains useful when package-targeted to the installed
+app, but the live web redirect discards route query parameters. DeeplinkX
+therefore does not reuse that short URL as a browser fallback.
 
 ### Fallback Support Matrix
 

--- a/doc/apps/threads.md
+++ b/doc/apps/threads.md
@@ -64,6 +64,25 @@ await deeplinkX.launchAction(Threads.createPost(
 ));
 ```
 
+### Search Action
+
+```dart
+await deeplinkX.launchAction(
+  Threads.search(query: 'flutter'),
+);
+```
+
+### Open Topic Tag Action
+
+```dart
+await deeplinkX.launchAction(
+  Threads.openTag(tag: 'flutter'),
+);
+```
+
+Search queries and topic tags must not be blank. DeeplinkX URI-encodes the
+supplied value without trimming or otherwise rewriting it.
+
 ## Platform-Specific Configuration
 
 ### iOS
@@ -108,6 +127,8 @@ DeeplinkX uses the following URLs for Threads:
 - `barcelona://user?username={username}` for profile native fallback
 - `barcelona://media?shortcode={postId}` for post/comments native fallback
 - `barcelona://create?text={text}` for compose native fallback
+- `barcelona://search?search_text={query}` for search
+- `barcelona://tag/{tag}` for topic tags
 - package-targeted Android intents for:
   - profile permalinks
   - post permalinks
@@ -117,6 +138,8 @@ DeeplinkX uses the following URLs for Threads:
 - `https://www.threads.com/@{username}`
 - `https://www.threads.com/@{username}/post/{postId}`
 - `https://www.threads.com/intent/post?text={text}`
+- `https://www.threads.com/search?q={query}`
+- `https://www.threads.com/tag/{tag}`
 
 ## Supported Fallback Stores
 
@@ -129,8 +152,10 @@ When Threads is not installed, DeeplinkX can redirect users to:
 
 - On Android, DeeplinkX first launches package-targeted Threads intents backed by Threads App Links metadata, then tries the native `barcelona://` scheme when available before using web or store fallback.
 - The `barcelona://` scheme is not vendor-documented. DeeplinkX pairs it with web fallbacks so profile, post, and compose flows still resolve somewhere useful if the scheme changes.
-- This release intentionally ships the stable, verified exposed deeplinks: profile, post permalink, and compose intent.
-- Search, tag, and feed-specific APIs are not included yet.
+- Search and topic tags are included because their native destinations passed
+  physical Android verification and have matching public web destinations.
+- Internal feed, messaging, followers, settings, and debug handlers are not
+  exposed.
 
 ## Check If Threads Is Installed
 

--- a/doc/apps/yandex_maps.md
+++ b/doc/apps/yandex_maps.md
@@ -10,7 +10,6 @@ panoramas.
 - Yandex Maps Android launch URLs: <https://yandex.com/dev/yandex-apps-launch-maps/doc/en/concepts/yandexmaps-android-app>
 - Yandex Maps iOS launch URLs: <https://yandex.com/dev/yandex-apps-launch-maps/doc/en/concepts/yandexmaps-ios-app>
 - Yandex Maps web launch URLs: <https://yandex.com/dev/yandex-apps-launch-maps/doc/en/concepts/yandexmaps-web>
-- Map Launcher Yandex Maps implementation: <https://github.com/mattermoran/map_launcher/blob/master/lib/src/directions_url.dart>
 
 ## Available Actions
 
@@ -136,11 +135,20 @@ Allow querying the package in `android/app/src/main/AndroidManifest.xml`:
 - Organization card: `yandexmaps://maps.yandex.com/?oid={objectId}`
 - What is here: `yandexmaps://?whatshere[point]={longitude},{latitude}&whatshere[zoom]={zoom}`
 - Directions: `yandexmaps://maps.yandex.com/?rtext={originLat},{originLng}~{destinationLat},{destinationLng}&rtt={mode}`
+- Destination-only directions: `yandexmaps://maps.yandex.com/?rtext=~{destinationLat},{destinationLng}&rtt={mode}`
 - Panorama: `yandexmaps://?panorama[point]={longitude},{latitude}&panorama[direction]={azimuth},{elevation}&panorama[span]={horizontal},{vertical}`
 
 Routes use latitude-longitude pairs in `rtext`. Map display, search areas,
 object lookup, and panorama points use longitude-latitude pairs, matching the
 Yandex Maps launch URL docs.
+
+Marker and route coordinate ordering, destination-only routes, and waypoint
+ordering remain compatible with existing integrations. Destination-only routes
+retain the leading `~` placeholder so Yandex uses the current location as the
+origin. DeeplinkX also
+validates provider ranges: zoom is 1 through 18, viewport deltas and panorama
+spans must be positive and finite, organization IDs must contain only digits,
+and panorama direction values must be finite and between 0 and 360.
 
 ## Fallback Behavior
 

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -60,6 +60,18 @@
         <package android:name="com.google.android.apps.maps" />
         <!-- Waze -->
         <package android:name="com.waze" />
+        <!-- Neshan -->
+        <package android:name="org.rajman.neshan.traffic.tehran.navigator" />
+        <!-- Amap -->
+        <package android:name="com.autonavi.minimap" />
+        <!-- Moovit -->
+        <package android:name="com.tranzmate" />
+        <!-- Baidu Maps -->
+        <package android:name="com.baidu.BaiduMap" />
+        <!-- 2GIS -->
+        <package android:name="ru.dublgis.dgismobile" />
+        <!-- Yandex Maps -->
+        <package android:name="ru.yandex.yandexmaps" />
 
         <!-- For store apps -->
         <!-- Google Play Store -->
@@ -80,6 +92,35 @@
         <intent>
             <action android:name="android.intent.action.VIEW" />
             <data android:scheme="barcelona" />
+        </intent>
+        <!-- Navigation app schemes used by fallback launch attempts -->
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="neshan" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="androidamap" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="amapuri" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="moovit" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="baidumap" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="dgis" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="yandexmaps" />
         </intent>
     </queries>
 </manifest>

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -39,6 +39,14 @@
 		<string>slack</string>
 		<string>comgooglemaps</string>
 		<string>waze</string>
+		<string>barcelona</string>
+		<string>neshan</string>
+		<string>iosamap</string>
+		<string>moovit</string>
+		<string>baidumap</string>
+		<string>dgis</string>
+		<string>yandexmaps</string>
+		<string>itms-apps</string>
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>

--- a/example/lib/pages/threads_page.dart
+++ b/example/lib/pages/threads_page.dart
@@ -15,6 +15,8 @@ class _ThreadsPageState extends State<ThreadsPage> {
   final _usernameController = TextEditingController(text: 'zuck');
   final _postIdController = TextEditingController(text: 'DY11ZLWG_eY');
   final _composeTextController = TextEditingController(text: 'Hello from DeeplinkX');
+  final _searchController = TextEditingController(text: 'flutter');
+  final _tagController = TextEditingController(text: 'Flutter');
   bool _fallback = true;
 
   @override
@@ -22,6 +24,8 @@ class _ThreadsPageState extends State<ThreadsPage> {
     _usernameController.dispose();
     _postIdController.dispose();
     _composeTextController.dispose();
+    _searchController.dispose();
+    _tagController.dispose();
     super.dispose();
   }
 
@@ -68,6 +72,46 @@ class _ThreadsPageState extends State<ThreadsPage> {
               }
             },
             child: const Text('Open Profile'),
+          ),
+          const SizedBox(height: 16),
+          const Text('Discovery Actions', style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+          const SizedBox(height: 8),
+          TextField(
+            controller: _searchController,
+            decoration: const InputDecoration(
+              labelText: 'Search Query',
+              hintText: 'Enter a Threads search query',
+              border: OutlineInputBorder(),
+            ),
+          ),
+          const SizedBox(height: 8),
+          ElevatedButton(
+            onPressed: () async {
+              if (_searchController.text.trim().isNotEmpty) {
+                await _deeplinkX.launchAction(
+                  Threads.search(query: _searchController.text, fallbackToStore: _fallback),
+                );
+              }
+            },
+            child: const Text('Search Threads'),
+          ),
+          const SizedBox(height: 8),
+          TextField(
+            controller: _tagController,
+            decoration: const InputDecoration(
+              labelText: 'Topic Tag',
+              hintText: 'Enter a Threads topic tag',
+              border: OutlineInputBorder(),
+            ),
+          ),
+          const SizedBox(height: 8),
+          ElevatedButton(
+            onPressed: () async {
+              if (_tagController.text.trim().isNotEmpty) {
+                await _deeplinkX.launchAction(Threads.openTag(tag: _tagController.text, fallbackToStore: _fallback));
+              }
+            },
+            child: const Text('Open Topic Tag'),
           ),
           const SizedBox(height: 16),
           const Text('Post Actions', style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),

--- a/example/lib/pages/two_gis_page.dart
+++ b/example/lib/pages/two_gis_page.dart
@@ -18,7 +18,7 @@ class _TwoGisPageState extends State<TwoGisPage> {
   final _originLngController = TextEditingController(text: '37.618423');
   final _destLatController = TextEditingController(text: '55.76009');
   final _destLngController = TextEditingController(text: '37.648801');
-  var _mode = TwoGisTravelMode.auto;
+  var _mode = TwoGisTravelMode.driving;
   bool _fallback = true;
 
   void _showInputError(final String message) {
@@ -80,9 +80,8 @@ class _TwoGisPageState extends State<TwoGisPage> {
           DropdownButton<TwoGisTravelMode>(
             value: _mode,
             isExpanded: true,
-            onChanged: (final mode) => setState(() => _mode = mode ?? TwoGisTravelMode.auto),
+            onChanged: (final mode) => setState(() => _mode = mode ?? TwoGisTravelMode.driving),
             items: const [
-              DropdownMenuItem(value: TwoGisTravelMode.auto, child: Text('Auto')),
               DropdownMenuItem(value: TwoGisTravelMode.driving, child: Text('Driving')),
               DropdownMenuItem(value: TwoGisTravelMode.transit, child: Text('Transit')),
               DropdownMenuItem(value: TwoGisTravelMode.walking, child: Text('Walking')),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -71,7 +71,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.3.8"
+    version: "1.3.9"
   deeplink_x_android:
     dependency: transitive
     description:

--- a/lib/src/apps/downloadable_apps/amap.dart
+++ b/lib/src/apps/downloadable_apps/amap.dart
@@ -1,6 +1,6 @@
 import 'package:deeplink_x/src/src.dart';
 
-const String _sourceApplication = 'deeplink_x';
+const String _defaultSourceApplication = 'deeplink_x';
 
 /// Amap (Gaode Maps) application.
 ///
@@ -46,20 +46,26 @@ class Amap extends App implements DownloadableApp {
 
   /// Creates an action to show the user's current location in Amap.
   static AmapMyLocationAction myLocation({
+    final String sourceApplication = _defaultSourceApplication,
     final bool fallbackToStore = false,
   }) =>
-      AmapMyLocationAction(fallbackToStore: fallbackToStore);
+      AmapMyLocationAction(
+        sourceApplication: sourceApplication,
+        fallbackToStore: fallbackToStore,
+      );
 
   /// Creates an action to show a coordinate marker in Amap.
   static AmapViewAction view({
     required final Coordinate coordinate,
     final String? title,
+    final String sourceApplication = _defaultSourceApplication,
     final bool convertFromWgs84 = false,
     final bool fallbackToStore = false,
   }) =>
       AmapViewAction(
         coordinate: coordinate,
         title: title,
+        sourceApplication: sourceApplication,
         convertFromWgs84: convertFromWgs84,
         fallbackToStore: fallbackToStore,
       );
@@ -68,12 +74,14 @@ class Amap extends App implements DownloadableApp {
   static AmapSearchAction search({
     required final String query,
     final AmapBounds? bounds,
+    final String sourceApplication = _defaultSourceApplication,
     final bool convertFromWgs84 = false,
     final bool fallbackToStore = false,
   }) =>
       AmapSearchAction(
         query: query,
         bounds: bounds,
+        sourceApplication: sourceApplication,
         convertFromWgs84: convertFromWgs84,
         fallbackToStore: fallbackToStore,
       );
@@ -81,10 +89,12 @@ class Amap extends App implements DownloadableApp {
   /// Creates a text-based directions action in Amap.
   static AmapDirectionsAction directions({
     required final String destination,
+    final String sourceApplication = _defaultSourceApplication,
     final bool fallbackToStore = false,
   }) =>
       AmapDirectionsAction(
         destination: destination,
+        sourceApplication: sourceApplication,
         fallbackToStore: fallbackToStore,
       );
 
@@ -96,6 +106,7 @@ class Amap extends App implements DownloadableApp {
     final String? originTitle,
     final List<AmapWaypoint> waypoints = const [],
     final AmapTravelMode mode = AmapTravelMode.driving,
+    final String sourceApplication = _defaultSourceApplication,
     final bool convertFromWgs84 = false,
     final bool fallbackToStore = false,
   }) =>
@@ -106,6 +117,7 @@ class Amap extends App implements DownloadableApp {
         originTitle: originTitle,
         waypoints: waypoints,
         mode: mode,
+        sourceApplication: sourceApplication,
         convertFromWgs84: convertFromWgs84,
         fallbackToStore: fallbackToStore,
       );
@@ -165,13 +177,19 @@ class AmapWaypoint {
 /// Opens Amap at the user's current location.
 class AmapMyLocationAction extends Amap implements IntentAppLinkAction, Fallbackable {
   /// Creates a new [AmapMyLocationAction].
-  AmapMyLocationAction({required super.fallbackToStore});
+  AmapMyLocationAction({
+    required super.fallbackToStore,
+    final String sourceApplication = _defaultSourceApplication,
+  }) : sourceApplication = _validatedSourceApplication(sourceApplication);
+
+  /// Identifier of the application launching Amap.
+  final String sourceApplication;
 
   @override
   Uri get appLink => Uri(
         scheme: 'iosamap',
         host: 'myLocation',
-        queryParameters: const {'sourceApplication': _sourceApplication},
+        queryParameters: {'sourceApplication': sourceApplication},
       );
 
   @override
@@ -181,7 +199,7 @@ class AmapMyLocationAction extends Amap implements IntentAppLinkAction, Fallback
         data: Uri(
           scheme: 'androidamap',
           host: 'myLocation',
-          queryParameters: const {'sourceApplication': _sourceApplication},
+          queryParameters: {'sourceApplication': sourceApplication},
         ).toString(),
         package: androidPackageName,
         flags: const [0x10000000],
@@ -198,8 +216,9 @@ class AmapViewAction extends Amap implements IntentAppLinkAction, Fallbackable, 
     required this.coordinate,
     required this.convertFromWgs84,
     required super.fallbackToStore,
+    final String sourceApplication = _defaultSourceApplication,
     this.title,
-  });
+  }) : sourceApplication = _validatedSourceApplication(sourceApplication);
 
   /// Coordinate to display.
   @override
@@ -210,6 +229,9 @@ class AmapViewAction extends Amap implements IntentAppLinkAction, Fallbackable, 
 
   /// Whether Amap should convert the coordinate from WGS84 to GCJ-02.
   final bool convertFromWgs84;
+
+  /// Identifier of the application launching Amap.
+  final String sourceApplication;
 
   @override
   Uri get appLink => _viewLink('iosamap');
@@ -230,8 +252,8 @@ class AmapViewAction extends Amap implements IntentAppLinkAction, Fallbackable, 
         scheme: scheme,
         host: 'viewMap',
         queryParameters: {
-          'sourceApplication': _sourceApplication,
-          if (title != null) 'poiname': title,
+          'sourceApplication': sourceApplication,
+          'poiname': title ?? 'Pin',
           'lat': coordinate.latitude.toString(),
           'lon': coordinate.longitude.toString(),
           'dev': _devValue(convertFromWgs84),
@@ -246,8 +268,9 @@ class AmapSearchAction extends Amap implements IntentAppLinkAction, Fallbackable
     required this.query,
     required this.convertFromWgs84,
     required super.fallbackToStore,
+    final String sourceApplication = _defaultSourceApplication,
     this.bounds,
-  });
+  }) : sourceApplication = _validatedSourceApplication(sourceApplication);
 
   /// Search query.
   @override
@@ -258,6 +281,9 @@ class AmapSearchAction extends Amap implements IntentAppLinkAction, Fallbackable
 
   /// Whether Amap should convert provided bounds from WGS84 to GCJ-02.
   final bool convertFromWgs84;
+
+  /// Identifier of the application launching Amap.
+  final String sourceApplication;
 
   @override
   Uri get appLink => Uri(
@@ -283,7 +309,7 @@ class AmapSearchAction extends Amap implements IntentAppLinkAction, Fallbackable
   Uri get fallbackLink => website;
 
   Map<String, String> _searchQueryParameters(final String queryKey) => {
-        'sourceApplication': _sourceApplication,
+        'sourceApplication': sourceApplication,
         queryKey: query,
         if (bounds != null) ...{
           'lat1': bounds!.topLeft.latitude.toString(),
@@ -301,14 +327,18 @@ class AmapDirectionsAction extends Amap implements IntentAppLinkAction, Fallback
   AmapDirectionsAction({
     required this.destination,
     required super.fallbackToStore,
-  });
+    final String sourceApplication = _defaultSourceApplication,
+  }) : sourceApplication = _validatedSourceApplication(sourceApplication);
 
   /// Destination name.
   @override
   final String destination;
 
+  /// Identifier of the application launching Amap.
+  final String sourceApplication;
+
   @override
-  Uri get appLink => _iosDirectionsLink({
+  Uri get appLink => _iosDirectionsLink(sourceApplication, {
         'dname': destination,
         'dev': '0',
         't': AmapTravelMode.driving.value,
@@ -318,11 +348,15 @@ class AmapDirectionsAction extends Amap implements IntentAppLinkAction, Fallback
   AndroidIntentOption get androidIntentOptions => AndroidIntentOption(
         action: 'android.intent.action.VIEW',
         category: 'android.intent.category.DEFAULT',
-        data: _androidDirectionsLink({
-          'dname': destination,
-          'dev': '0',
-          't': AmapTravelMode.driving.value,
-        }).toString(),
+        data: Uri(
+          scheme: 'androidamap',
+          host: 'keywordNavi',
+          queryParameters: {
+            'sourceApplication': sourceApplication,
+            'keyword': destination,
+            'style': '2',
+          },
+        ).toString(),
         package: androidPackageName,
         flags: const [0x10000000],
       );
@@ -341,10 +375,11 @@ class AmapDirectionsWithCoordsAction extends Amap
     required this.mode,
     required this.convertFromWgs84,
     required super.fallbackToStore,
+    final String sourceApplication = _defaultSourceApplication,
     this.origin,
     this.destinationTitle,
     this.originTitle,
-  });
+  }) : sourceApplication = _validatedSourceApplication(sourceApplication);
 
   /// Destination coordinate.
   @override
@@ -368,14 +403,17 @@ class AmapDirectionsWithCoordsAction extends Amap
   /// Whether Amap should convert coordinates from WGS84 to GCJ-02.
   final bool convertFromWgs84;
 
+  /// Identifier of the application launching Amap.
+  final String sourceApplication;
+
   @override
-  Uri get appLink => _iosDirectionsLink(_routeQueryParameters);
+  Uri get appLink => _iosDirectionsLink(sourceApplication, _routeQueryParameters);
 
   @override
   AndroidIntentOption get androidIntentOptions => AndroidIntentOption(
         action: 'android.intent.action.VIEW',
         category: 'android.intent.category.DEFAULT',
-        data: _androidDirectionsLink(_routeQueryParameters).toString(),
+        data: _androidDirectionsLink(sourceApplication, _routeQueryParameters).toString(),
         package: androidPackageName,
         flags: const [0x10000000],
       );
@@ -403,23 +441,42 @@ class AmapDirectionsWithCoordsAction extends Amap
       };
 }
 
-Uri _androidDirectionsLink(final Map<String, String> queryParameters) => Uri(
+Uri _androidDirectionsLink(
+  final String sourceApplication,
+  final Map<String, String> queryParameters,
+) =>
+    Uri(
       scheme: 'amapuri',
       host: 'route',
       path: '/plan/',
       queryParameters: {
-        'sourceApplication': _sourceApplication,
+        'sourceApplication': sourceApplication,
         ...queryParameters,
       },
     );
 
-Uri _iosDirectionsLink(final Map<String, String> queryParameters) => Uri(
+Uri _iosDirectionsLink(
+  final String sourceApplication,
+  final Map<String, String> queryParameters,
+) =>
+    Uri(
       scheme: 'iosamap',
       host: 'path',
       queryParameters: {
-        'sourceApplication': _sourceApplication,
+        'sourceApplication': sourceApplication,
         ...queryParameters,
       },
     );
 
 String _devValue(final bool convertFromWgs84) => convertFromWgs84 ? '1' : '0';
+
+String _validatedSourceApplication(final String sourceApplication) {
+  if (sourceApplication.trim().isEmpty) {
+    throw ArgumentError.value(
+      sourceApplication,
+      'sourceApplication',
+      'must not be blank',
+    );
+  }
+  return sourceApplication;
+}

--- a/lib/src/apps/downloadable_apps/baidu_maps.dart
+++ b/lib/src/apps/downloadable_apps/baidu_maps.dart
@@ -1,6 +1,6 @@
 import 'package:deeplink_x/src/src.dart';
 
-const _sourceApplication = 'deeplink_x';
+const _defaultSourceApplication = 'deeplink_x';
 const _currentLocation = '我的位置';
 const _newTaskFlag = 0x10000000;
 
@@ -9,10 +9,23 @@ const _newTaskFlag = 0x10000000;
 /// Implements Baidu Maps URI actions for Android and iOS.
 class BaiduMaps extends App implements DownloadableApp {
   /// Creates a new [BaiduMaps] instance.
-  BaiduMaps({this.fallbackToStore = false});
+  BaiduMaps({
+    this.fallbackToStore = false,
+    final String sourceApplication = _defaultSourceApplication,
+  }) : sourceApplication = _validatedSourceApplication(sourceApplication);
 
   /// Creates an action to open the Baidu Maps app.
-  factory BaiduMaps.open({final bool fallbackToStore = false}) => BaiduMaps(fallbackToStore: fallbackToStore);
+  factory BaiduMaps.open({
+    final bool fallbackToStore = false,
+    final String sourceApplication = _defaultSourceApplication,
+  }) =>
+      BaiduMaps(
+        fallbackToStore: fallbackToStore,
+        sourceApplication: sourceApplication,
+      );
+
+  /// Identifier of the application launching Baidu Maps.
+  final String sourceApplication;
 
   /// Store actions for Baidu Maps.
   @override
@@ -53,6 +66,7 @@ class BaiduMaps extends App implements DownloadableApp {
     final int? zoom,
     final BaiduMapsCoordType coordType = BaiduMapsCoordType.bd09ll,
     final bool traffic = false,
+    final String sourceApplication = _defaultSourceApplication,
     final bool fallbackToStore = false,
   }) =>
       BaiduMapsViewAction(
@@ -63,6 +77,7 @@ class BaiduMaps extends App implements DownloadableApp {
         title: title,
         content: content,
         zoom: zoom,
+        sourceApplication: sourceApplication,
       );
 
   /// Creates an action that searches for places.
@@ -74,6 +89,7 @@ class BaiduMaps extends App implements DownloadableApp {
     final int? radius,
     final int? zoom,
     final BaiduMapsCoordType coordType = BaiduMapsCoordType.bd09ll,
+    final String sourceApplication = _defaultSourceApplication,
     final bool fallbackToStore = false,
   }) =>
       BaiduMapsSearchAction(
@@ -85,6 +101,7 @@ class BaiduMaps extends App implements DownloadableApp {
         bounds: bounds,
         radius: radius,
         zoom: zoom,
+        sourceApplication: sourceApplication,
       );
 
   /// Creates an action that searches nearby places.
@@ -93,6 +110,7 @@ class BaiduMaps extends App implements DownloadableApp {
     final Coordinate? center,
     final int? radius,
     final BaiduMapsCoordType coordType = BaiduMapsCoordType.bd09ll,
+    final String sourceApplication = _defaultSourceApplication,
     final bool fallbackToStore = false,
   }) =>
       BaiduMapsNearbySearchAction(
@@ -101,6 +119,7 @@ class BaiduMaps extends App implements DownloadableApp {
         fallbackToStore: fallbackToStore,
         center: center,
         radius: radius,
+        sourceApplication: sourceApplication,
       );
 
   /// Creates an action that searches a transit line.
@@ -108,6 +127,7 @@ class BaiduMaps extends App implements DownloadableApp {
     required final String name,
     final String? region,
     final int? zoom,
+    final String sourceApplication = _defaultSourceApplication,
     final bool fallbackToStore = false,
   }) =>
       BaiduMapsLineAction(
@@ -115,6 +135,7 @@ class BaiduMaps extends App implements DownloadableApp {
         fallbackToStore: fallbackToStore,
         region: region,
         zoom: zoom,
+        sourceApplication: sourceApplication,
       );
 
   /// Creates an action that plans a route to [destination].
@@ -124,6 +145,7 @@ class BaiduMaps extends App implements DownloadableApp {
     final String? region,
     final BaiduMapsTravelMode mode = BaiduMapsTravelMode.driving,
     final BaiduMapsCoordType coordType = BaiduMapsCoordType.bd09ll,
+    final String sourceApplication = _defaultSourceApplication,
     final bool fallbackToStore = false,
   }) =>
       BaiduMapsDirectionsAction(
@@ -133,6 +155,7 @@ class BaiduMaps extends App implements DownloadableApp {
         fallbackToStore: fallbackToStore,
         origin: origin,
         region: region,
+        sourceApplication: sourceApplication,
       );
 
   /// Creates an action that plans a route to [destination] coordinates.
@@ -144,6 +167,7 @@ class BaiduMaps extends App implements DownloadableApp {
     final String? region,
     final BaiduMapsTravelMode mode = BaiduMapsTravelMode.driving,
     final BaiduMapsCoordType coordType = BaiduMapsCoordType.bd09ll,
+    final String sourceApplication = _defaultSourceApplication,
     final bool fallbackToStore = false,
   }) =>
       BaiduMapsDirectionsWithCoordsAction(
@@ -155,19 +179,24 @@ class BaiduMaps extends App implements DownloadableApp {
         destinationTitle: destinationTitle,
         originTitle: originTitle,
         region: region,
+        sourceApplication: sourceApplication,
       );
 
   /// Creates an action that starts native turn-by-turn navigation.
   static BaiduMapsNavigateAction navigate({
     required final Coordinate destination,
+    final String? destinationTitle,
     final BaiduMapsNavigationMode mode = BaiduMapsNavigationMode.driving,
     final BaiduMapsCoordType coordType = BaiduMapsCoordType.bd09ll,
+    final String sourceApplication = _defaultSourceApplication,
     final bool fallbackToStore = false,
   }) =>
       BaiduMapsNavigateAction(
         destination: destination,
+        destinationTitle: destinationTitle,
         mode: mode,
         coordType: coordType,
+        sourceApplication: sourceApplication,
         fallbackToStore: fallbackToStore,
       );
 }
@@ -264,6 +293,7 @@ class BaiduMapsViewAction extends BaiduMaps implements IntentAppLinkAction, Fall
     required this.coordType,
     required this.traffic,
     required super.fallbackToStore,
+    super.sourceApplication = _defaultSourceApplication,
     this.title,
     this.content,
     this.zoom,
@@ -288,21 +318,32 @@ class BaiduMapsViewAction extends BaiduMaps implements IntentAppLinkAction, Fall
   /// Whether to show real-time traffic.
   final bool traffic;
 
+  Map<String, String> get _queryParameters => {
+        'location': coordinate.toString(),
+        'title': title ?? 'Pin',
+        'content': content ?? 'Description',
+        if (zoom != null) 'zoom': zoom!.toString(),
+        'coord_type': coordType.value,
+        if (traffic) 'traffic': 'on',
+      };
+
   @override
   Uri get appLink => _baiduUri(
         'marker',
-        {
-          'location': coordinate.toString(),
-          if (title != null) 'title': title!,
-          if (content != null) 'content': content!,
-          if (zoom != null) 'zoom': zoom!.toString(),
-          'coord_type': coordType.value,
-          if (traffic) 'traffic': 'on',
-        },
+        _queryParameters,
+        sourceApplication: sourceApplication,
+        platformPrefix: 'ios',
       );
 
   @override
-  AndroidIntentOption get androidIntentOptions => _androidIntentOptions(appLink);
+  AndroidIntentOption get androidIntentOptions => _androidIntentOptions(
+        _baiduUri(
+          'marker',
+          _queryParameters,
+          sourceApplication: sourceApplication,
+          platformPrefix: 'andr',
+        ),
+      );
 
   @override
   Uri get fallbackLink => website;
@@ -315,6 +356,7 @@ class BaiduMapsSearchAction extends BaiduMaps implements IntentAppLinkAction, Fa
     required this.query,
     required this.coordType,
     required super.fallbackToStore,
+    super.sourceApplication = _defaultSourceApplication,
     this.region,
     this.center,
     this.bounds,
@@ -344,22 +386,33 @@ class BaiduMapsSearchAction extends BaiduMaps implements IntentAppLinkAction, Fa
   /// Coordinate system for [center] and [bounds].
   final BaiduMapsCoordType coordType;
 
+  Map<String, String> get _queryParameters => {
+        'query': query,
+        if (region != null) 'region': region!,
+        if (center != null) 'location': center!.toString(),
+        if (bounds != null) 'bounds': bounds!.value,
+        if (radius != null) 'radius': radius!.toString(),
+        if (zoom != null) 'zoom': zoom!.toString(),
+        'coord_type': coordType.value,
+      };
+
   @override
   Uri get appLink => _baiduUri(
         'place/search',
-        {
-          'query': query,
-          if (region != null) 'region': region!,
-          if (center != null) 'location': center!.toString(),
-          if (bounds != null) 'bounds': bounds!.value,
-          if (radius != null) 'radius': radius!.toString(),
-          if (zoom != null) 'zoom': zoom!.toString(),
-          'coord_type': coordType.value,
-        },
+        _queryParameters,
+        sourceApplication: sourceApplication,
+        platformPrefix: 'ios',
       );
 
   @override
-  AndroidIntentOption get androidIntentOptions => _androidIntentOptions(appLink);
+  AndroidIntentOption get androidIntentOptions => _androidIntentOptions(
+        _baiduUri(
+          'place/search',
+          _queryParameters,
+          sourceApplication: sourceApplication,
+          platformPrefix: 'andr',
+        ),
+      );
 
   @override
   Uri get fallbackLink => website;
@@ -372,6 +425,7 @@ class BaiduMapsNearbySearchAction extends BaiduMaps implements IntentAppLinkActi
     required this.query,
     required this.coordType,
     required super.fallbackToStore,
+    super.sourceApplication = _defaultSourceApplication,
     this.center,
     this.radius,
   });
@@ -390,17 +444,31 @@ class BaiduMapsNearbySearchAction extends BaiduMaps implements IntentAppLinkActi
 
   @override
   Uri get appLink => _baiduUri(
-        'place/nearby',
+        'nearbysearch',
         {
           'query': query,
-          if (center != null) 'location': center!.toString(),
+          if (center != null) 'center': center!.toString(),
           if (radius != null) 'radius': radius!.toString(),
           'coord_type': coordType.value,
         },
+        sourceApplication: sourceApplication,
+        platformPrefix: 'ios',
       );
 
   @override
-  AndroidIntentOption get androidIntentOptions => _androidIntentOptions(appLink);
+  AndroidIntentOption get androidIntentOptions => _androidIntentOptions(
+        _baiduUri(
+          'place/nearby',
+          {
+            'query': query,
+            if (center != null) 'location': center!.toString(),
+            if (radius != null) 'radius': radius!.toString(),
+            'coord_type': coordType.value,
+          },
+          sourceApplication: sourceApplication,
+          platformPrefix: 'andr',
+        ),
+      );
 
   @override
   Uri get fallbackLink => website;
@@ -412,9 +480,10 @@ class BaiduMapsLineAction extends BaiduMaps implements IntentAppLinkAction, Fall
   BaiduMapsLineAction({
     required this.name,
     required super.fallbackToStore,
-    this.region,
+    final String? region,
     this.zoom,
-  });
+    super.sourceApplication = _defaultSourceApplication,
+  }) : region = _validatedRegion(region);
 
   /// Transit line name.
   final String name;
@@ -425,18 +494,29 @@ class BaiduMapsLineAction extends BaiduMaps implements IntentAppLinkAction, Fall
   /// Optional zoom level.
   final int? zoom;
 
+  Map<String, String> get _queryParameters => {
+        'name': name,
+        'region': region!,
+        if (zoom != null) 'zoom': zoom!.toString(),
+      };
+
   @override
   Uri get appLink => _baiduUri(
         'line',
-        {
-          'name': name,
-          if (region != null) 'region': region!,
-          if (zoom != null) 'zoom': zoom!.toString(),
-        },
+        _queryParameters,
+        sourceApplication: sourceApplication,
+        platformPrefix: 'ios',
       );
 
   @override
-  AndroidIntentOption get androidIntentOptions => _androidIntentOptions(appLink);
+  AndroidIntentOption get androidIntentOptions => _androidIntentOptions(
+        _baiduUri(
+          'line',
+          _queryParameters,
+          sourceApplication: sourceApplication,
+          platformPrefix: 'andr',
+        ),
+      );
 
   @override
   Uri get fallbackLink => website;
@@ -450,6 +530,7 @@ class BaiduMapsDirectionsAction extends BaiduMaps implements IntentAppLinkAction
     required this.mode,
     required this.coordType,
     required super.fallbackToStore,
+    super.sourceApplication = _defaultSourceApplication,
     this.origin,
     this.region,
   });
@@ -470,20 +551,31 @@ class BaiduMapsDirectionsAction extends BaiduMaps implements IntentAppLinkAction
   /// Coordinate system used by route planning.
   final BaiduMapsCoordType coordType;
 
+  Map<String, String> get _queryParameters => {
+        'origin': origin ?? _currentLocation,
+        'destination': destination,
+        if (region != null) 'region': region!,
+        'mode': mode.value,
+        'coord_type': coordType.value,
+      };
+
   @override
   Uri get appLink => _baiduUri(
         'direction',
-        {
-          'origin': origin ?? _currentLocation,
-          'destination': destination,
-          if (region != null) 'region': region!,
-          'mode': mode.value,
-          'coord_type': coordType.value,
-        },
+        _queryParameters,
+        sourceApplication: sourceApplication,
+        platformPrefix: 'ios',
       );
 
   @override
-  AndroidIntentOption get androidIntentOptions => _androidIntentOptions(appLink);
+  AndroidIntentOption get androidIntentOptions => _androidIntentOptions(
+        _baiduUri(
+          'direction',
+          _queryParameters,
+          sourceApplication: sourceApplication,
+          platformPrefix: 'andr',
+        ),
+      );
 
   @override
   Uri get fallbackLink => website;
@@ -498,6 +590,7 @@ class BaiduMapsDirectionsWithCoordsAction extends BaiduMaps
     required this.mode,
     required this.coordType,
     required super.fallbackToStore,
+    super.sourceApplication = _defaultSourceApplication,
     this.origin,
     this.destinationTitle,
     this.originTitle,
@@ -526,20 +619,31 @@ class BaiduMapsDirectionsWithCoordsAction extends BaiduMaps
   /// Coordinate system used by route planning.
   final BaiduMapsCoordType coordType;
 
+  Map<String, String> get _queryParameters => {
+        'origin': origin != null ? _routePoint(origin!, originTitle) : originTitle ?? _currentLocation,
+        'destination': _routePoint(destination, destinationTitle),
+        if (region != null) 'region': region!,
+        'mode': mode.value,
+        'coord_type': coordType.value,
+      };
+
   @override
   Uri get appLink => _baiduUri(
         'direction',
-        {
-          'origin': origin != null ? _routePoint(origin!, originTitle) : originTitle ?? _currentLocation,
-          'destination': _routePoint(destination, destinationTitle),
-          if (region != null) 'region': region!,
-          'mode': mode.value,
-          'coord_type': coordType.value,
-        },
+        _queryParameters,
+        sourceApplication: sourceApplication,
+        platformPrefix: 'ios',
       );
 
   @override
-  AndroidIntentOption get androidIntentOptions => _androidIntentOptions(appLink);
+  AndroidIntentOption get androidIntentOptions => _androidIntentOptions(
+        _baiduUri(
+          'direction',
+          _queryParameters,
+          sourceApplication: sourceApplication,
+          platformPrefix: 'andr',
+        ),
+      );
 
   @override
   Uri get fallbackLink => website;
@@ -553,10 +657,15 @@ class BaiduMapsNavigateAction extends BaiduMaps implements IntentAppLinkAction, 
     required this.mode,
     required this.coordType,
     required super.fallbackToStore,
+    this.destinationTitle,
+    super.sourceApplication = _defaultSourceApplication,
   });
 
   /// Destination coordinate.
   final Coordinate destination;
+
+  /// Optional destination display name.
+  final String? destinationTitle;
 
   /// Native navigation mode.
   final BaiduMapsNavigationMode mode;
@@ -565,20 +674,30 @@ class BaiduMapsNavigateAction extends BaiduMaps implements IntentAppLinkAction, 
   final BaiduMapsCoordType coordType;
 
   @override
-  Uri get appLink => _navigationLink(mode.iosPath);
+  Uri get appLink => _navigationLink(mode.iosPath, platformPrefix: 'ios');
 
   @override
-  AndroidIntentOption get androidIntentOptions => _androidIntentOptions(_navigationLink(mode.androidPath));
+  AndroidIntentOption get androidIntentOptions => _androidIntentOptions(
+        _navigationLink(mode.androidPath, platformPrefix: 'andr'),
+      );
 
   @override
   Uri get fallbackLink => website;
 
-  Uri _navigationLink(final String path) => _baiduUri(
+  Uri _navigationLink(
+    final String path, {
+    required final String platformPrefix,
+  }) =>
+      _baiduUri(
         path,
         {
           _navigationLocationKey: destination.toString(),
+          if (platformPrefix == 'ios' && mode == BaiduMapsNavigationMode.driving)
+            'query': destinationTitle ?? 'Destination',
           'coord_type': coordType.value,
         },
+        sourceApplication: sourceApplication,
+        platformPrefix: platformPrefix,
       );
 
   String get _navigationLocationKey {
@@ -589,13 +708,19 @@ class BaiduMapsNavigateAction extends BaiduMaps implements IntentAppLinkAction, 
   }
 }
 
-Uri _baiduUri(final String path, final Map<String, String> parameters) => Uri(
+Uri _baiduUri(
+  final String path,
+  final Map<String, String> parameters, {
+  required final String sourceApplication,
+  required final String platformPrefix,
+}) =>
+    Uri(
       scheme: 'baidumap',
       host: 'map',
       path: path,
       queryParameters: {
         ...parameters,
-        'src': _sourceApplication,
+        'src': '$platformPrefix.$sourceApplication',
       },
     );
 
@@ -611,5 +736,23 @@ String _routePoint(final Coordinate coordinate, final String? name) {
   if (name == null) {
     return latLng;
   }
-  return '$latLng|name:$name';
+  return 'name:$name|$latLng';
+}
+
+String _validatedSourceApplication(final String sourceApplication) {
+  if (sourceApplication.trim().isEmpty) {
+    throw ArgumentError.value(
+      sourceApplication,
+      'sourceApplication',
+      'must not be blank',
+    );
+  }
+  return sourceApplication;
+}
+
+String _validatedRegion(final String? region) {
+  if (region == null || region.trim().isEmpty) {
+    throw ArgumentError.value(region, 'region', 'must not be blank');
+  }
+  return region;
 }

--- a/lib/src/apps/downloadable_apps/moovit.dart
+++ b/lib/src/apps/downloadable_apps/moovit.dart
@@ -42,10 +42,12 @@ class Moovit extends App implements DownloadableApp {
   /// Creates an action that shows nearby transit options at [coordinate].
   static MoovitViewAction view({
     required final Coordinate coordinate,
+    final String partnerId = 'deeplink_x',
     final bool fallbackToStore = false,
   }) =>
       MoovitViewAction(
         coordinate: coordinate,
+        partnerId: partnerId,
         fallbackToStore: fallbackToStore,
       );
 
@@ -55,6 +57,7 @@ class Moovit extends App implements DownloadableApp {
     final Coordinate? origin,
     final String? destinationTitle,
     final String? originTitle,
+    final String partnerId = 'deeplink_x',
     final bool fallbackToStore = false,
   }) =>
       MoovitDirectionsWithCoordsAction(
@@ -62,6 +65,7 @@ class Moovit extends App implements DownloadableApp {
         origin: origin,
         destinationTitle: destinationTitle,
         originTitle: originTitle,
+        partnerId: partnerId,
         fallbackToStore: fallbackToStore,
       );
 }
@@ -72,11 +76,15 @@ class MoovitViewAction extends Moovit implements IntentAppLinkAction, AppLinkApp
   MoovitViewAction({
     required this.coordinate,
     required super.fallbackToStore,
-  });
+    final String partnerId = 'deeplink_x',
+  }) : partnerId = _validatedPartnerId(partnerId);
 
   /// Coordinate to show nearby transit options for.
   @override
   final Coordinate coordinate;
+
+  /// Partner identifier required by Moovit deeplinks.
+  final String partnerId;
 
   @override
   Uri get appLink => Uri(
@@ -85,6 +93,7 @@ class MoovitViewAction extends Moovit implements IntentAppLinkAction, AppLinkApp
         queryParameters: {
           'lat': coordinate.latitude.toString(),
           'lon': coordinate.longitude.toString(),
+          'partner_id': partnerId,
         },
       );
 
@@ -110,7 +119,8 @@ class MoovitDirectionsWithCoordsAction extends Moovit
     required this.destinationTitle,
     required this.originTitle,
     required super.fallbackToStore,
-  });
+    final String partnerId = 'deeplink_x',
+  }) : partnerId = _validatedPartnerId(partnerId);
 
   /// Destination coordinate.
   @override
@@ -124,6 +134,9 @@ class MoovitDirectionsWithCoordsAction extends Moovit
 
   /// Optional origin label.
   final String? originTitle;
+
+  /// Partner identifier required by Moovit deeplinks.
+  final String partnerId;
 
   @override
   Uri get appLink {
@@ -141,6 +154,7 @@ class MoovitDirectionsWithCoordsAction extends Moovit
         if (routeOrigin != null) 'orig_lat': routeOrigin.latitude.toString(),
         if (routeOrigin != null) 'orig_lon': routeOrigin.longitude.toString(),
         if (routeOriginTitle != null) 'orig_name': routeOriginTitle,
+        'partner_id': partnerId,
       },
     );
   }
@@ -155,4 +169,11 @@ class MoovitDirectionsWithCoordsAction extends Moovit
 
   @override
   Uri get fallbackLink => website;
+}
+
+String _validatedPartnerId(final String partnerId) {
+  if (partnerId.trim().isEmpty) {
+    throw ArgumentError.value(partnerId, 'partnerId', 'must not be blank');
+  }
+  return partnerId;
 }

--- a/lib/src/apps/downloadable_apps/neshan.dart
+++ b/lib/src/apps/downloadable_apps/neshan.dart
@@ -37,7 +37,7 @@ class Neshan extends App implements DownloadableApp {
 
   /// Neshan web map fallback.
   @override
-  Uri get website => Uri.parse('https://nshn.ir');
+  Uri get website => Uri.parse('https://neshan.org/maps');
 
   /// Creates an action that shows [coordinate] on the map.
   static NeshanViewAction view({
@@ -82,7 +82,14 @@ class NeshanViewAction extends Neshan implements IntentAppLinkAction, AppLinkApp
   @override
   AndroidIntentOption get androidIntentOptions => AndroidIntentOption(
         action: 'action_view',
-        data: fallbackLink.toString(),
+        data: Uri(
+          scheme: 'https',
+          host: 'nshn.ir',
+          queryParameters: {
+            'lat': coordinate.latitude.toString(),
+            'lng': coordinate.longitude.toString(),
+          },
+        ).toString(),
         package: androidPackageName,
         flags: const [0x10000000],
       );
@@ -90,11 +97,8 @@ class NeshanViewAction extends Neshan implements IntentAppLinkAction, AppLinkApp
   @override
   Uri get fallbackLink => Uri(
         scheme: 'https',
-        host: 'nshn.ir',
-        queryParameters: {
-          'lat': coordinate.latitude.toString(),
-          'lng': coordinate.longitude.toString(),
-        },
+        host: 'neshan.org',
+        pathSegments: ['maps', 'share', coordinate.toString()],
       );
 }
 
@@ -130,13 +134,15 @@ class NeshanDirectionsWithCoordsAction extends Neshan
   @override
   AndroidIntentOption get androidIntentOptions => AndroidIntentOption(
         action: 'action_view',
-        data: fallbackLink.toString(),
+        data: _androidRouteLink.toString(),
         package: androidPackageName,
         flags: const [0x10000000],
       );
 
   @override
-  Uri get fallbackLink {
+  Uri get fallbackLink => website;
+
+  Uri get _androidRouteLink {
     final routeOrigin = origin;
 
     return Uri(

--- a/lib/src/apps/downloadable_apps/threads.dart
+++ b/lib/src/apps/downloadable_apps/threads.dart
@@ -101,6 +101,26 @@ class Threads extends App implements DownloadableApp {
         text: text,
         fallbackToStore: fallbackToStore,
       );
+
+  /// Creates an action to search Threads for [query].
+  static ThreadsSearchAction search({
+    required final String query,
+    final bool fallbackToStore = false,
+  }) =>
+      ThreadsSearchAction(
+        query: query,
+        fallbackToStore: fallbackToStore,
+      );
+
+  /// Creates an action to open a Threads topic tag.
+  static ThreadsOpenTagAction openTag({
+    required final String tag,
+    final bool fallbackToStore = false,
+  }) =>
+      ThreadsOpenTagAction(
+        tag: tag,
+        fallbackToStore: fallbackToStore,
+      );
 }
 
 /// An action to open a specific profile in the Threads app.
@@ -228,4 +248,80 @@ class ThreadsCreatePostAction extends Threads implements IntentAppLinkAction, Ap
         pathSegments: ['intent', 'post'],
         queryParameters: {'text': text},
       );
+}
+
+/// An action to search Threads for a text query.
+class ThreadsSearchAction extends Threads implements IntentAppLinkAction, AppLinkAppAction, Fallbackable {
+  /// Creates a new [ThreadsSearchAction] instance.
+  ThreadsSearchAction({
+    required final String query,
+    required super.fallbackToStore,
+  }) : query = _requireNonBlank(query, 'query');
+
+  /// The text to search for.
+  final String query;
+
+  @override
+  Uri get appLink => Uri(
+        scheme: 'barcelona',
+        host: 'search',
+        queryParameters: {'search_text': query},
+      );
+
+  @override
+  AndroidIntentOption get androidIntentOptions => AndroidIntentOption(
+        action: 'action_view',
+        data: fallbackLink.toString(),
+        package: androidPackageName,
+        flags: const [0x10000000],
+      );
+
+  @override
+  Uri get fallbackLink => Uri(
+        scheme: 'https',
+        host: 'www.threads.com',
+        path: '/search',
+        queryParameters: {'q': query},
+      );
+}
+
+/// An action to open a Threads topic tag.
+class ThreadsOpenTagAction extends Threads implements IntentAppLinkAction, AppLinkAppAction, Fallbackable {
+  /// Creates a new [ThreadsOpenTagAction] instance.
+  ThreadsOpenTagAction({
+    required final String tag,
+    required super.fallbackToStore,
+  }) : tag = _requireNonBlank(tag, 'tag');
+
+  /// The topic tag to open.
+  final String tag;
+
+  @override
+  Uri get appLink => Uri(
+        scheme: 'barcelona',
+        host: 'tag',
+        pathSegments: [tag],
+      );
+
+  @override
+  AndroidIntentOption get androidIntentOptions => AndroidIntentOption(
+        action: 'action_view',
+        data: fallbackLink.toString(),
+        package: androidPackageName,
+        flags: const [0x10000000],
+      );
+
+  @override
+  Uri get fallbackLink => Uri(
+        scheme: 'https',
+        host: 'www.threads.com',
+        pathSegments: ['tag', tag],
+      );
+}
+
+String _requireNonBlank(final String value, final String name) {
+  if (value.trim().isEmpty) {
+    throw ArgumentError.value(value, name, 'must not be blank');
+  }
+  return value;
 }

--- a/lib/src/apps/downloadable_apps/two_gis.dart
+++ b/lib/src/apps/downloadable_apps/two_gis.dart
@@ -25,7 +25,7 @@ class TwoGis extends App implements DownloadableApp {
   static TwoGisDirectionsWithCoordsAction directionsWithCoords({
     required final Coordinate destination,
     final Coordinate? origin,
-    final TwoGisTravelMode mode = TwoGisTravelMode.auto,
+    final TwoGisTravelMode mode = TwoGisTravelMode.driving,
     final bool fallbackToStore = false,
   }) =>
       TwoGisDirectionsWithCoordsAction(
@@ -72,22 +72,26 @@ class TwoGis extends App implements DownloadableApp {
 
 /// 2GIS travel modes.
 enum TwoGisTravelMode {
-  /// Automatic mode selection.
-  auto('auto'),
+  /// Compatibility alias for car routing.
+  @Deprecated('Use TwoGisTravelMode.driving instead.')
+  auto('car', androidValue: 'car'),
 
   /// Car routing.
-  driving('car'),
+  driving('car', androidValue: 'car'),
 
   /// Public transit routing.
-  transit('bus'),
+  transit('ctx', androidValue: 'bus'),
 
   /// Walking routing.
-  walking('pedestrian');
+  walking('pedestrian', androidValue: 'pedestrian');
 
-  const TwoGisTravelMode(this.value);
+  const TwoGisTravelMode(this.value, {required this.androidValue});
 
-  /// URI path value.
+  /// Provider-documented URI path value used by custom links and fallbacks.
   final String value;
+
+  /// URI path value accepted by the current Android app.
+  final String androidValue;
 }
 
 /// Shows a coordinate in 2GIS.
@@ -125,7 +129,7 @@ class TwoGisDirectionsWithCoordsAction extends TwoGis
     required this.destination,
     required super.fallbackToStore,
     this.origin,
-    this.mode = TwoGisTravelMode.auto,
+    this.mode = TwoGisTravelMode.driving,
   });
 
   /// Destination coordinate.
@@ -138,28 +142,28 @@ class TwoGisDirectionsWithCoordsAction extends TwoGis
   /// Travel mode.
   final TwoGisTravelMode mode;
 
-  String get _routePath => [
+  String _routePath(final String travelMode) => [
         'routeSearch',
         'rsType',
-        mode.value,
+        travelMode,
         if (origin != null) ...['from', _lngLat(origin!)],
         'to',
         _lngLat(destination),
       ].join('/');
 
   @override
-  Uri get appLink => _twoGisUri(_routePath);
+  Uri get appLink => _twoGisUri(_routePath(mode.value));
 
   @override
   AndroidIntentOption get androidIntentOptions => AndroidIntentOption(
         action: 'action_view',
-        data: appLink.toString(),
+        data: _twoGisUri(_routePath(mode.androidValue)).toString(),
         package: androidPackageName,
         flags: const [0x10000000],
       );
 
   @override
-  Uri get fallbackLink => _twoGisWebUri(_routePath);
+  Uri get fallbackLink => _twoGisWebUri(_routePath(mode.value));
 }
 
 String _lngLat(final Coordinate coordinate) => '${coordinate.longitude},${coordinate.latitude}';

--- a/lib/src/apps/downloadable_apps/yandex_maps.dart
+++ b/lib/src/apps/downloadable_apps/yandex_maps.dart
@@ -260,7 +260,10 @@ class YandexMapsOpenMapAction extends YandexMaps implements IntentAppLinkAction,
     this.viewport,
     this.layer = YandexMapsMapLayer.map,
     this.showTraffic = false,
-  });
+  }) {
+    _validateZoom(zoom);
+    _validateViewport(viewport);
+  }
 
   /// Optional map center.
   final Coordinate? center;
@@ -307,7 +310,9 @@ class YandexMapsViewAction extends YandexMaps implements IntentAppLinkAction, Fa
     this.zoom,
     this.layer = YandexMapsMapLayer.map,
     this.showTraffic = false,
-  });
+  }) {
+    _validateZoom(zoom);
+  }
 
   /// Coordinate to display as a placemark.
   @override
@@ -353,7 +358,10 @@ class YandexMapsSearchAction extends YandexMaps implements IntentAppLinkAction, 
     this.viewport,
     this.layer = YandexMapsMapLayer.map,
     this.showTraffic = false,
-  });
+  }) {
+    _validateZoom(zoom);
+    _validateViewport(viewport);
+  }
 
   /// Search query.
   @override
@@ -402,7 +410,15 @@ class YandexMapsOrganizationAction extends YandexMaps implements IntentAppLinkAc
   YandexMapsOrganizationAction({
     required this.objectId,
     required super.fallbackToStore,
-  });
+  }) {
+    if (!RegExp(r'^\d+$').hasMatch(objectId)) {
+      throw ArgumentError.value(
+        objectId,
+        'objectId',
+        'must contain only digits',
+      );
+    }
+  }
 
   /// Yandex organization ID.
   final String objectId;
@@ -430,7 +446,9 @@ class YandexMapsWhatIsHereAction extends YandexMaps implements IntentAppLinkActi
     required this.coordinate,
     required this.zoom,
     required super.fallbackToStore,
-  });
+  }) {
+    _validateZoom(zoom);
+  }
 
   /// Object coordinate.
   final Coordinate coordinate;
@@ -480,7 +498,7 @@ class YandexMapsDirectionsWithCoordsAction extends YandexMaps
 
   Map<String, String> get _queryParameters => {
         'rtext': [
-          if (origin != null) _latLng(origin!),
+          if (origin != null) _latLng(origin!) else '',
           for (final waypoint in waypoints) _latLng(waypoint.coordinate),
           _latLng(destination),
         ].join('~'),
@@ -505,7 +523,10 @@ class YandexMapsPanoramaAction extends YandexMaps implements IntentAppLinkAction
     required super.fallbackToStore,
     this.direction,
     this.span,
-  });
+  }) {
+    _validatePanoramaDirection(direction);
+    _validatePanoramaSpan(span);
+  }
 
   /// Panorama coordinate.
   final Coordinate coordinate;
@@ -581,3 +602,56 @@ AndroidIntentOption _androidIntentOptions(final IntentAppLinkAction action) => A
       package: 'ru.yandex.yandexmaps',
       flags: const [0x10000000],
     );
+
+void _validateZoom(final int? zoom) {
+  if (zoom != null && (zoom < 1 || zoom > 18)) {
+    throw ArgumentError.value(
+      zoom,
+      'zoom',
+      'must be between 1 and 18 for Yandex Maps mobile URLs',
+    );
+  }
+}
+
+void _validateViewport(final YandexMapsViewport? viewport) {
+  if (viewport == null) {
+    return;
+  }
+  if (!_isPositiveFinite(viewport.longitudeDelta) || !_isPositiveFinite(viewport.latitudeDelta)) {
+    throw ArgumentError.value(
+      viewport,
+      'viewport',
+      'longitudeDelta and latitudeDelta must be positive finite values',
+    );
+  }
+}
+
+void _validatePanoramaDirection(final YandexMapsPanoramaDirection? direction) {
+  if (direction == null) {
+    return;
+  }
+  if (!_isAngle(direction.azimuth) || !_isAngle(direction.elevation)) {
+    throw ArgumentError.value(
+      direction,
+      'direction',
+      'azimuth and elevation must be finite values between 0 and 360',
+    );
+  }
+}
+
+void _validatePanoramaSpan(final YandexMapsPanoramaSpan? span) {
+  if (span == null) {
+    return;
+  }
+  if (!_isPositiveFinite(span.horizontal) || !_isPositiveFinite(span.vertical)) {
+    throw ArgumentError.value(
+      span,
+      'span',
+      'horizontal and vertical must be positive finite values',
+    );
+  }
+}
+
+bool _isPositiveFinite(final double value) => value.isFinite && value > 0;
+
+bool _isAngle(final double value) => value.isFinite && value >= 0 && value <= 360;

--- a/lib/src/core/deeplink_x.dart
+++ b/lib/src/core/deeplink_x.dart
@@ -52,9 +52,7 @@ class DeeplinkX {
               return true;
             }
           }
-        }
-
-        if (action is AppLinkAppAction) {
+        } else if (action is AppLinkAppAction) {
           final isLaunched = await _launcherUtil.launchUrl(action.appLink);
           if (isLaunched) {
             return true;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: deeplink_x
 description: Type-safe Flutter deeplinks for WhatsApp, Telegram, Instagram, YouTube, Google Maps, Waze and app stores, with automatic store and web fallback.
-version: 1.3.8
+version: 1.3.9
 homepage: https://github.com/DeepLinkX/DeeplinkX
 repository: https://github.com/DeepLinkX/DeeplinkX
 issue_tracker: https://github.com/DeepLinkX/DeeplinkX/issues

--- a/test/deeplink_x_test.dart
+++ b/test/deeplink_x_test.dart
@@ -88,7 +88,12 @@ void main() {
 
       test('Threads', () {
         final action = Threads.open();
+        final searchAction = Threads.search(query: 'flutter');
+        final tagAction = Threads.openTag(tag: 'flutter');
+
         expect(action, isA<App>());
+        expect(searchAction, isA<ThreadsSearchAction>());
+        expect(tagAction, isA<ThreadsOpenTagAction>());
       });
 
       test('TikTok', () {

--- a/test/src/apps/amap_test.dart
+++ b/test/src/apps/amap_test.dart
@@ -46,6 +46,17 @@ void main() {
       expect(action.fallbackLink.toString(), 'https://www.amap.com');
     });
 
+    test('myLocation action accepts a custom source application', () {
+      final action = Amap.myLocation(sourceApplication: 'com.example.client');
+
+      expect(action.sourceApplication, 'com.example.client');
+      expect(action.appLink.queryParameters['sourceApplication'], 'com.example.client');
+      expect(
+        Uri.parse(action.androidIntentOptions.data!).queryParameters['sourceApplication'],
+        'com.example.client',
+      );
+    });
+
     test('view action creates marker links', () {
       final action = Amap.view(
         coordinate: const Coordinate(latitude: 39.98848272, longitude: 116.47560823),
@@ -72,6 +83,18 @@ void main() {
       expect(intentUri.queryParameters['lon'], '116.47560823');
       expect(intentUri.queryParameters['dev'], '1');
       expect(action.fallbackLink.toString(), 'https://www.amap.com');
+    });
+
+    test('view action supplies the provider-required marker name', () {
+      final action = Amap.view(
+        coordinate: const Coordinate(latitude: 39.9, longitude: 116.4),
+      );
+
+      expect(action.appLink.queryParameters['poiname'], 'Pin');
+      expect(
+        Uri.parse(action.androidIntentOptions.data!).queryParameters['poiname'],
+        'Pin',
+      );
     });
 
     test('search action creates platform-specific query keys', () {
@@ -119,13 +142,11 @@ void main() {
       expect(action.appLink.queryParameters['t'], '0');
 
       final intentUri = Uri.parse(action.androidIntentOptions.data!);
-      expect(intentUri.scheme, 'amapuri');
-      expect(intentUri.host, 'route');
-      expect(intentUri.path, '/plan/');
+      expect(intentUri.scheme, 'androidamap');
+      expect(intentUri.host, 'keywordnavi');
       expect(intentUri.queryParameters['sourceApplication'], 'deeplink_x');
-      expect(intentUri.queryParameters['dname'], 'Amap HQ');
-      expect(intentUri.queryParameters['dev'], '0');
-      expect(intentUri.queryParameters['t'], '0');
+      expect(intentUri.queryParameters['keyword'], 'Amap HQ');
+      expect(intentUri.queryParameters['style'], '2');
       expect(action.fallbackLink.toString(), 'https://www.amap.com');
     });
 
@@ -211,6 +232,17 @@ void main() {
         fallbackToStore: true,
       );
       expect(directionsAction.fallbackToStore, true);
+    });
+
+    test('actions reject a blank source application', () {
+      expect(() => Amap.myLocation(sourceApplication: '  '), throwsArgumentError);
+      expect(
+        () => Amap.view(
+          coordinate: const Coordinate(latitude: 1, longitude: 2),
+          sourceApplication: '',
+        ),
+        throwsArgumentError,
+      );
     });
   });
 }

--- a/test/src/apps/baidu_maps_test.dart
+++ b/test/src/apps/baidu_maps_test.dart
@@ -22,6 +22,7 @@ void main() {
       expect(action.macosBundleIdentifier, null);
 
       expect(action.fallbackToStore, false);
+      expect(action.sourceApplication, 'deeplink_x');
       expect(action.storeActions.length, 2);
     });
 
@@ -54,15 +55,28 @@ void main() {
       expect(action.appLink.queryParameters['zoom'], '16');
       expect(action.appLink.queryParameters['coord_type'], 'wgs84');
       expect(action.appLink.queryParameters['traffic'], 'on');
-      expect(action.appLink.queryParameters['src'], 'deeplink_x');
+      expect(action.appLink.queryParameters['src'], 'ios.deeplink_x');
 
       final intentUri = Uri.parse(action.androidIntentOptions.data!);
       expect(intentUri.path, '/marker');
       expect(intentUri.queryParameters['location'], '39.915,116.404');
+      expect(intentUri.queryParameters['src'], 'andr.deeplink_x');
       expect(action.androidIntentOptions.action, 'action_view');
       expect(action.androidIntentOptions.package, 'com.baidu.BaiduMap');
       expect(action.androidIntentOptions.flags, const [0x10000000]);
       expect(action.fallbackLink.toString(), 'https://map.baidu.com');
+    });
+
+    test('view action supplies map_launcher-compatible marker defaults', () {
+      final action = BaiduMaps.view(
+        coordinate: const Coordinate(latitude: 39.915, longitude: 116.404),
+      );
+
+      expect(action.appLink.queryParameters['title'], 'Pin');
+      expect(action.appLink.queryParameters['content'], 'Description');
+      final intentUri = Uri.parse(action.androidIntentOptions.data!);
+      expect(intentUri.queryParameters['title'], 'Pin');
+      expect(intentUri.queryParameters['content'], 'Description');
     });
 
     test('search action creates place search links', () {
@@ -93,6 +107,7 @@ void main() {
       final intentUri = Uri.parse(action.androidIntentOptions.data!);
       expect(intentUri.path, '/place/search');
       expect(intentUri.queryParameters['query'], 'coffee');
+      expect(intentUri.queryParameters['src'], 'andr.deeplink_x');
       expect(action.fallbackLink.toString(), 'https://map.baidu.com');
     });
 
@@ -104,13 +119,25 @@ void main() {
         coordType: BaiduMapsCoordType.bd09mc,
       );
 
-      expect(action.appLink.path, '/place/nearby');
+      expect(action.appLink.path, '/nearbysearch');
       expect(action.appLink.queryParameters['query'], 'hotel');
-      expect(action.appLink.queryParameters['location'], '31.2304,121.4737');
+      expect(action.appLink.queryParameters['center'], '31.2304,121.4737');
+      expect(action.appLink.queryParameters.containsKey('location'), false);
       expect(action.appLink.queryParameters['radius'], '2500');
       expect(action.appLink.queryParameters['coord_type'], 'bd09mc');
-      expect(Uri.parse(action.androidIntentOptions.data!).path, '/place/nearby');
+      final intentUri = Uri.parse(action.androidIntentOptions.data!);
+      expect(intentUri.path, '/place/nearby');
+      expect(intentUri.queryParameters['location'], '31.2304,121.4737');
+      expect(intentUri.queryParameters.containsKey('center'), false);
       expect(action.fallbackLink.toString(), 'https://map.baidu.com');
+    });
+
+    test('line action requires a nonblank region', () {
+      expect(() => BaiduMaps.line(name: 'Line 1'), throwsArgumentError);
+      expect(
+        () => BaiduMaps.line(name: 'Line 1', region: '  '),
+        throwsArgumentError,
+      );
     });
 
     test('line action creates transit line links', () {
@@ -165,15 +192,15 @@ void main() {
       );
 
       expect(action.appLink.path, '/direction');
-      expect(action.appLink.queryParameters['origin'], 'latlng:39.9042,116.4074|name:Start');
-      expect(action.appLink.queryParameters['destination'], 'latlng:39.915,116.404|name:Tiananmen');
+      expect(action.appLink.queryParameters['origin'], 'name:Start|latlng:39.9042,116.4074');
+      expect(action.appLink.queryParameters['destination'], 'name:Tiananmen|latlng:39.915,116.404');
       expect(action.appLink.queryParameters['region'], 'Beijing');
       expect(action.appLink.queryParameters['mode'], 'walking');
       expect(action.appLink.queryParameters['coord_type'], 'wgs84');
 
       final intentUri = Uri.parse(action.androidIntentOptions.data!);
       expect(intentUri.path, '/direction');
-      expect(intentUri.queryParameters['destination'], 'latlng:39.915,116.404|name:Tiananmen');
+      expect(intentUri.queryParameters['destination'], 'name:Tiananmen|latlng:39.915,116.404');
       expect(action.fallbackLink.toString(), 'https://map.baidu.com');
 
       final currentLocationAction = BaiduMaps.directionsWithCoords(
@@ -186,12 +213,18 @@ void main() {
     test('navigate action creates native navigation links', () {
       final drivingAction = BaiduMaps.navigate(
         destination: const Coordinate(latitude: 39.915, longitude: 116.404),
+        destinationTitle: 'Tiananmen',
       );
 
       expect(drivingAction.appLink.path, '/navi');
       expect(drivingAction.appLink.queryParameters['location'], '39.915,116.404');
       expect(drivingAction.appLink.queryParameters['coord_type'], 'bd09ll');
-      expect(Uri.parse(drivingAction.androidIntentOptions.data!).path, '/navi');
+      expect(drivingAction.appLink.queryParameters['query'], 'Tiananmen');
+      expect(drivingAction.appLink.queryParameters['src'], 'ios.deeplink_x');
+      final drivingIntentUri = Uri.parse(drivingAction.androidIntentOptions.data!);
+      expect(drivingIntentUri.path, '/navi');
+      expect(drivingIntentUri.queryParameters.containsKey('query'), false);
+      expect(drivingIntentUri.queryParameters['src'], 'andr.deeplink_x');
 
       final walkingAction = BaiduMaps.navigate(
         destination: const Coordinate(latitude: 39.915, longitude: 116.404),
@@ -240,7 +273,11 @@ void main() {
       expect(nearbySearchAction.query, 'atm');
       expect(nearbySearchAction.fallbackToStore, true);
 
-      final lineAction = BaiduMaps.line(name: 'Line 2', fallbackToStore: true);
+      final lineAction = BaiduMaps.line(
+        name: 'Line 2',
+        region: 'Beijing',
+        fallbackToStore: true,
+      );
       expect(lineAction.name, 'Line 2');
       expect(lineAction.fallbackToStore, true);
 
@@ -261,6 +298,30 @@ void main() {
       );
       expect(navigateAction.destination.toString(), '1.0,2.0');
       expect(navigateAction.fallbackToStore, true);
+    });
+
+    test('actions accept a custom source application', () {
+      final action = BaiduMaps.directions(
+        destination: 'Station',
+        sourceApplication: 'com.example.client',
+      );
+
+      expect(action.sourceApplication, 'com.example.client');
+      expect(action.appLink.queryParameters['src'], 'ios.com.example.client');
+      expect(
+        Uri.parse(action.androidIntentOptions.data!).queryParameters['src'],
+        'andr.com.example.client',
+      );
+    });
+
+    test('actions reject a blank source application', () {
+      expect(
+        () => BaiduMaps.search(
+          query: 'coffee',
+          sourceApplication: ' ',
+        ),
+        throwsArgumentError,
+      );
     });
   });
 }

--- a/test/src/apps/moovit_test.dart
+++ b/test/src/apps/moovit_test.dart
@@ -53,9 +53,10 @@ void main() {
       expect(action, isInstanceOf<IntentAppLinkAction>());
       expect(action, isInstanceOf<Fallbackable>());
       expect(action.coordinate, const Coordinate(latitude: 40.7128, longitude: -74.0060));
-      expect(action.appLink.toString(), 'moovit://nearby?lat=40.7128&lon=-74.006');
+      expect(action.partnerId, 'deeplink_x');
+      expect(action.appLink.toString(), 'moovit://nearby?lat=40.7128&lon=-74.006&partner_id=deeplink_x');
       expect(action.androidIntentOptions.action, 'action_view');
-      expect(action.androidIntentOptions.data, 'moovit://nearby?lat=40.7128&lon=-74.006');
+      expect(action.androidIntentOptions.data, 'moovit://nearby?lat=40.7128&lon=-74.006&partner_id=deeplink_x');
       expect(action.androidIntentOptions.package, 'com.tranzmate');
       expect(action.androidIntentOptions.flags, const [0x10000000]);
       expect(action.fallbackLink.toString(), 'https://www.moovit.com/');
@@ -67,6 +68,7 @@ void main() {
         originTitle: 'Times Square',
         destination: const Coordinate(latitude: 40.7527, longitude: -73.9772),
         destinationTitle: 'Grand Central',
+        partnerId: 'deeplink_x_tests',
       );
 
       expect(action, isInstanceOf<AppLinkAppAction>());
@@ -76,14 +78,15 @@ void main() {
       expect(action.originTitle, 'Times Square');
       expect(action.destination, const Coordinate(latitude: 40.7527, longitude: -73.9772));
       expect(action.destinationTitle, 'Grand Central');
+      expect(action.partnerId, 'deeplink_x_tests');
       expect(
         action.appLink.toString(),
-        'moovit://directions?dest_lat=40.7527&dest_lon=-73.9772&dest_name=Grand+Central&orig_lat=40.758&orig_lon=-73.9855&orig_name=Times+Square',
+        'moovit://directions?dest_lat=40.7527&dest_lon=-73.9772&dest_name=Grand+Central&orig_lat=40.758&orig_lon=-73.9855&orig_name=Times+Square&partner_id=deeplink_x_tests',
       );
       expect(action.androidIntentOptions.action, 'action_view');
       expect(
         action.androidIntentOptions.data,
-        'moovit://directions?dest_lat=40.7527&dest_lon=-73.9772&dest_name=Grand+Central&orig_lat=40.758&orig_lon=-73.9855&orig_name=Times+Square',
+        'moovit://directions?dest_lat=40.7527&dest_lon=-73.9772&dest_name=Grand+Central&orig_lat=40.758&orig_lon=-73.9855&orig_name=Times+Square&partner_id=deeplink_x_tests',
       );
       expect(action.androidIntentOptions.package, 'com.tranzmate');
       expect(action.androidIntentOptions.flags, const [0x10000000]);
@@ -98,7 +101,27 @@ void main() {
       expect(action.origin, null);
       expect(action.originTitle, null);
       expect(action.destinationTitle, null);
-      expect(action.appLink.toString(), 'moovit://directions?dest_lat=40.7527&dest_lon=-73.9772');
+      expect(
+        action.appLink.toString(),
+        'moovit://directions?dest_lat=40.7527&dest_lon=-73.9772&partner_id=deeplink_x',
+      );
+    });
+
+    test('rejects blank partner identifiers', () {
+      expect(
+        () => Moovit.view(
+          coordinate: const Coordinate(latitude: 40.7128, longitude: -74.0060),
+          partnerId: '   ',
+        ),
+        throwsArgumentError,
+      );
+      expect(
+        () => Moovit.directionsWithCoords(
+          destination: const Coordinate(latitude: 40.7527, longitude: -73.9772),
+          partnerId: '',
+        ),
+        throwsArgumentError,
+      );
     });
 
     test('actions keep fallback flag', () {

--- a/test/src/apps/neshan_test.dart
+++ b/test/src/apps/neshan_test.dart
@@ -17,7 +17,7 @@ void main() {
 
       expect(action.customScheme, 'neshan');
       expect(action.androidPackageName, 'org.rajman.neshan.traffic.tehran.navigator');
-      expect(action.website.toString(), 'https://nshn.ir');
+      expect(action.website.toString(), 'https://neshan.org/maps');
       expect(action.supportedPlatforms, containsAll(<PlatformType>[PlatformType.ios, PlatformType.android]));
       expect(action.supportedPlatforms.length, 2);
       expect(action.macosBundleIdentifier, null);
@@ -58,7 +58,7 @@ void main() {
       expect(action.androidIntentOptions.data, 'https://nshn.ir?lat=35.6892&lng=51.389');
       expect(action.androidIntentOptions.package, 'org.rajman.neshan.traffic.tehran.navigator');
       expect(action.androidIntentOptions.flags, const [0x10000000]);
-      expect(action.fallbackLink.toString(), 'https://nshn.ir?lat=35.6892&lng=51.389');
+      expect(action.fallbackLink.toString(), 'https://neshan.org/maps/share/35.6892,51.389');
     });
 
     test('directionsWithCoords action builds route with origin', () {
@@ -80,7 +80,7 @@ void main() {
       );
       expect(action.androidIntentOptions.package, 'org.rajman.neshan.traffic.tehran.navigator');
       expect(action.androidIntentOptions.flags, const [0x10000000]);
-      expect(action.fallbackLink.toString(), 'https://nshn.ir/?origin=35.6892%2C51.389&destination=35.7%2C51.4');
+      expect(action.fallbackLink.toString(), 'https://neshan.org/maps');
     });
 
     test('directionsWithCoords action supports current-location origin', () {
@@ -90,7 +90,11 @@ void main() {
 
       expect(action.origin, null);
       expect(action.appLink.toString(), 'neshan://?destination=35.7%2C51.4');
-      expect(action.fallbackLink.toString(), 'https://nshn.ir/?destination=35.7%2C51.4');
+      expect(
+        action.androidIntentOptions.data,
+        'https://nshn.ir/?destination=35.7%2C51.4',
+      );
+      expect(action.fallbackLink.toString(), 'https://neshan.org/maps');
     });
 
     test('actions keep fallback flag', () {

--- a/test/src/apps/threads_test.dart
+++ b/test/src/apps/threads_test.dart
@@ -168,6 +168,41 @@ void main() {
       );
     });
 
+    test('search action creates correct type and URIs', () {
+      final action = Threads.search(query: 'flutter maps');
+
+      expect(action, isInstanceOf<IntentAppLinkAction>());
+      expect(action, isInstanceOf<AppLinkAppAction>());
+      expect(action, isInstanceOf<Fallbackable>());
+      expect(action.query, 'flutter maps');
+      expect(action.appLink.toString(), 'barcelona://search?search_text=flutter+maps');
+      expect(action.fallbackLink.toString(), 'https://www.threads.com/search?q=flutter+maps');
+      expect(action.androidIntentOptions.action, 'action_view');
+      expect(action.androidIntentOptions.data, action.fallbackLink.toString());
+      expect(action.androidIntentOptions.package, 'com.instagram.barcelona');
+      expect(action.androidIntentOptions.flags, const [0x10000000]);
+    });
+
+    test('openTag action creates correct type and URIs', () {
+      final action = Threads.openTag(tag: 'Flutter Dev');
+
+      expect(action, isInstanceOf<IntentAppLinkAction>());
+      expect(action, isInstanceOf<AppLinkAppAction>());
+      expect(action, isInstanceOf<Fallbackable>());
+      expect(action.tag, 'Flutter Dev');
+      expect(action.appLink.toString(), 'barcelona://tag/Flutter%20Dev');
+      expect(action.fallbackLink.toString(), 'https://www.threads.com/tag/Flutter%20Dev');
+      expect(action.androidIntentOptions.action, 'action_view');
+      expect(action.androidIntentOptions.data, action.fallbackLink.toString());
+      expect(action.androidIntentOptions.package, 'com.instagram.barcelona');
+      expect(action.androidIntentOptions.flags, const [0x10000000]);
+    });
+
+    test('new actions reject blank values', () {
+      expect(() => Threads.search(query: '  '), throwsArgumentError);
+      expect(() => Threads.openTag(tag: '\n'), throwsArgumentError);
+    });
+
     test('open action with fallbackToStore creates Threads instance with correct properties', () {
       final action = Threads.open(fallbackToStore: true);
 
@@ -223,6 +258,14 @@ void main() {
       );
       expect(createPostAction.text, 'Hello from Threads');
       expect(createPostAction.fallbackToStore, true);
+
+      final searchAction = Threads.search(query: 'flutter', fallbackToStore: true);
+      expect(searchAction.query, 'flutter');
+      expect(searchAction.fallbackToStore, true);
+
+      final tagAction = Threads.openTag(tag: 'Flutter', fallbackToStore: true);
+      expect(tagAction.tag, 'Flutter');
+      expect(tagAction.fallbackToStore, true);
     });
   });
 }

--- a/test/src/apps/two_gis_test.dart
+++ b/test/src/apps/two_gis_test.dart
@@ -42,10 +42,19 @@ void main() {
     });
 
     test('travel modes expose provider values', () {
-      expect(TwoGisTravelMode.auto.value, 'auto');
+      // ignore: deprecated_member_use_from_same_package
+      expect(TwoGisTravelMode.auto.value, 'car');
       expect(TwoGisTravelMode.driving.value, 'car');
-      expect(TwoGisTravelMode.transit.value, 'bus');
+      expect(TwoGisTravelMode.transit.value, 'ctx');
       expect(TwoGisTravelMode.walking.value, 'pedestrian');
+    });
+
+    test('travel modes expose Android app values', () {
+      // ignore: deprecated_member_use_from_same_package
+      expect(TwoGisTravelMode.auto.androidValue, 'car');
+      expect(TwoGisTravelMode.driving.androidValue, 'car');
+      expect(TwoGisTravelMode.transit.androidValue, 'bus');
+      expect(TwoGisTravelMode.walking.androidValue, 'pedestrian');
     });
 
     test('view action creates iOS marker, Android route, and fallback URLs', () {
@@ -87,15 +96,18 @@ void main() {
       expect(action.fallbackToStore, true);
       expect(
         action.appLink.toString(),
-        'dgis://2gis.ru/routeSearch/rsType/bus/from/37.618423,55.751244/to/37.648801,55.76009',
+        'dgis://2gis.ru/routeSearch/rsType/ctx/from/37.618423,55.751244/to/37.648801,55.76009',
       );
       expect(action.androidIntentOptions.action, 'action_view');
-      expect(action.androidIntentOptions.data, action.appLink.toString());
+      expect(
+        action.androidIntentOptions.data,
+        'dgis://2gis.ru/routeSearch/rsType/bus/from/37.618423,55.751244/to/37.648801,55.76009',
+      );
       expect(action.androidIntentOptions.package, 'ru.dublgis.dgismobile');
       expect(action.androidIntentOptions.flags, [0x10000000]);
       expect(
         action.fallbackLink.toString(),
-        'https://2gis.ru/routeSearch/rsType/bus/from/37.618423,55.751244/to/37.648801,55.76009',
+        'https://2gis.ru/routeSearch/rsType/ctx/from/37.618423,55.751244/to/37.648801,55.76009',
       );
     });
 
@@ -103,9 +115,9 @@ void main() {
       final action = TwoGis.directionsWithCoords(destination: destination);
 
       expect(action.origin, null);
-      expect(action.mode, TwoGisTravelMode.auto);
-      expect(action.appLink.toString(), 'dgis://2gis.ru/routeSearch/rsType/auto/to/37.648801,55.76009');
-      expect(action.fallbackLink.toString(), 'https://2gis.ru/routeSearch/rsType/auto/to/37.648801,55.76009');
+      expect(action.mode, TwoGisTravelMode.driving);
+      expect(action.appLink.toString(), 'dgis://2gis.ru/routeSearch/rsType/car/to/37.648801,55.76009');
+      expect(action.fallbackLink.toString(), 'https://2gis.ru/routeSearch/rsType/car/to/37.648801,55.76009');
     });
   });
 }

--- a/test/src/apps/yandex_maps_test.dart
+++ b/test/src/apps/yandex_maps_test.dart
@@ -212,8 +212,22 @@ void main() {
       expect(action.origin, null);
       expect(action.waypoints, isEmpty);
       expect(action.mode, YandexMapsTravelMode.driving);
-      expect(action.appLink.queryParameters['rtext'], '55.76009,37.648801');
+      expect(action.appLink.queryParameters['rtext'], '~55.76009,37.648801');
       expect(action.appLink.queryParameters['rtt'], 'auto');
+    });
+
+    test('directionsWithCoords preserves current location before waypoints', () {
+      final action = YandexMaps.directionsWithCoords(
+        destination: destination,
+        waypoints: const [
+          YandexMapsWaypoint(coordinate: Coordinate(latitude: 55.745719, longitude: 37.604337)),
+        ],
+      );
+
+      expect(
+        action.appLink.queryParameters['rtext'],
+        '~55.745719,37.604337~55.76009,37.648801',
+      );
     });
 
     test('directionsWithCoords action supports walking mode', () {
@@ -248,6 +262,69 @@ void main() {
       expect(
         Uri.parse(action.androidIntentOptions.data!).queryParameters['panorama[direction]'],
         '228.97,6.060547',
+      );
+    });
+
+    test('mobile zoom values must be between 1 and 18', () {
+      expect(() => YandexMaps.openMap(zoom: 0), throwsArgumentError);
+      expect(() => YandexMaps.view(coordinate: center, zoom: 19), throwsArgumentError);
+      expect(
+        () => YandexMaps.search(query: 'cafe', zoom: -1),
+        throwsArgumentError,
+      );
+      expect(
+        () => YandexMaps.whatIsHere(coordinate: center, zoom: 19),
+        throwsArgumentError,
+      );
+    });
+
+    test('organization IDs must contain only digits', () {
+      expect(
+        () => YandexMaps.organization(objectId: 'org-1221676748'),
+        throwsArgumentError,
+      );
+      expect(() => YandexMaps.organization(objectId: ''), throwsArgumentError);
+    });
+
+    test('viewports require positive finite deltas', () {
+      expect(
+        () => YandexMaps.openMap(
+          viewport: const YandexMapsViewport(
+            longitudeDelta: 0,
+            latitudeDelta: 1,
+          ),
+        ),
+        throwsArgumentError,
+      );
+      expect(
+        () => YandexMaps.search(
+          query: 'cafe',
+          viewport: const YandexMapsViewport(
+            longitudeDelta: double.infinity,
+            latitudeDelta: 1,
+          ),
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('panorama direction and span values are validated', () {
+      expect(
+        () => YandexMaps.panorama(
+          coordinate: center,
+          direction: const YandexMapsPanoramaDirection(
+            azimuth: 361,
+            elevation: 10,
+          ),
+        ),
+        throwsArgumentError,
+      );
+      expect(
+        () => YandexMaps.panorama(
+          coordinate: center,
+          span: const YandexMapsPanoramaSpan(horizontal: 120, vertical: 0),
+        ),
+        throwsArgumentError,
       );
     });
   });

--- a/test/src/core/deeplink_x_test.dart
+++ b/test/src/core/deeplink_x_test.dart
@@ -18,6 +18,11 @@ class MockUniversalLinkAction extends Mock implements UniversalLinkAppAction {}
 
 class MockAppLinkAction extends Mock implements AppLinkAppAction {}
 
+class MockIntentAppLinkFallbackAction extends Mock implements IntentAppLinkAction, AppLinkAppAction, Fallbackable {}
+
+class MockIntentAppUniversalAction extends Mock
+    implements IntentAppLinkAction, AppLinkAppAction, UniversalLinkAppAction, Fallbackable {}
+
 class MockFallbackAction extends Mock implements AppAction, Fallbackable {}
 
 class MockDownloadableAction extends Mock implements AppAction, DownloadableApp {}
@@ -150,6 +155,47 @@ void main() {
       expect(result, isTrue);
       verify(() => mockLauncherUtil.launchIntent(options)).called(1);
       verify(() => mockLauncherUtil.launchUrl(appLink)).called(1);
+    });
+
+    test('does not retry the same app link for combined intent actions', () async {
+      final action = MockIntentAppLinkFallbackAction();
+      const options = AndroidIntentOption(action: 'action');
+      final appLink = Uri.parse('scheme://path');
+      final fallback = Uri.parse('https://fallback');
+
+      when(() => action.androidIntentOptions).thenReturn(options);
+      when(() => action.appLink).thenReturn(appLink);
+      when(() => action.fallbackLink).thenReturn(fallback);
+      when(() => mockLauncherUtil.launchIntent(options)).thenAnswer((final _) async => false);
+      when(() => mockLauncherUtil.launchUrl(appLink)).thenAnswer((final _) async => false);
+
+      final result = await deeplinkX.launchAction(action);
+
+      expect(result, isTrue);
+      verify(() => mockLauncherUtil.launchUrl(appLink)).called(1);
+      verify(() => mockLauncherUtil.launchUrl(fallback)).called(1);
+    });
+
+    test('tries a distinct universal link after a combined intent app link', () async {
+      final action = MockIntentAppUniversalAction();
+      const options = AndroidIntentOption(action: 'action');
+      final appLink = Uri.parse('scheme://path');
+      final universalLink = Uri.parse('https://universal');
+
+      when(() => action.androidIntentOptions).thenReturn(options);
+      when(() => action.appLink).thenReturn(appLink);
+      when(() => action.universalLink).thenReturn(universalLink);
+      when(() => mockLauncherUtil.launchIntent(options)).thenAnswer((final _) async => false);
+      when(() => mockLauncherUtil.launchUrl(appLink)).thenAnswer((final _) async => false);
+
+      final result = await deeplinkX.launchAction(action);
+
+      expect(result, isTrue);
+      verifyInOrder([
+        () => mockLauncherUtil.launchIntent(options),
+        () => mockLauncherUtil.launchUrl(appLink),
+        () => mockLauncherUtil.launchUrl(universalLink),
+      ]);
     });
 
     test('launches universal link action', () async {


### PR DESCRIPTION
## Summary

- prevent duplicate app-link attempts for combined intent actions
- add device-verified Threads search and topic-tag actions
- correct Neshan, Amap, Moovit, Baidu Maps, 2GIS, and Yandex Maps URI contracts, validation, and fallbacks
- configure audited iOS schemes and Android package/intent visibility in the example project
- document Telegram Android setup and strengthen navigation-provider contribution requirements

## Verification

- `dart format .`
- `flutter analyze --no-pub`
- `flutter test --no-pub` — 415 tests passed
- `flutter build apk --debug --no-pub`

No dependency, lockfile, or version changes are included.