### PR TITLE
ci: harden and optimize GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -3,14 +3,18 @@ name: Test & Coveralls
 on:
   push:
     branches: [ master ]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
   pull_request:
     branches: [ master ]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
   workflow_dispatch:
 
 permissions:
   contents: read
-  checks: write
-  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -23,19 +27,22 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Set up Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: ${{ env.FLUTTER_CHANNEL }}
           cache: true
           pub-cache: true
-          cache-key: "deeplinkx-ci-flutter-:os:-:channel:-:version:-:arch:-:hash:"
-          pub-cache-key: "deeplinkx-ci-flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
+          cache-key: "deeplinkx-flutter-:os:-:channel:-:version:-:arch:-:hash:"
+          pub-cache-key: "deeplinkx-pub-:os:-:channel:-:version:-:arch:-:hash:"
 
       - name: Flutter version
         run: flutter --version
@@ -53,7 +60,7 @@ jobs:
         run: flutter test --coverage
 
       - name: Upload coverage to Coveralls
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: coverage/lcov.info

--- a/.github/workflows/deploy-example-web.yml
+++ b/.github/workflows/deploy-example-web.yml
@@ -6,22 +6,19 @@ on:
     paths:
       - "example/**"
       - "lib/**"
-      - "packages/**"
       - "analysis_options.yaml"
       - "pubspec.yaml"
       - "pubspec.lock"
       - ".github/workflows/deploy-example-web.yml"
   workflow_dispatch:
 
-# Required for GitHub Pages
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: "pages"
-  cancel-in-progress: true
+  # Never cancel an in-flight production deployment; queued runs are superseded.
+  cancel-in-progress: false
 
 env:
   FLUTTER_VERSION: ${{ vars.FLUTTER_VERSION || '3.41.1' }}
@@ -32,28 +29,25 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Setup Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: ${{ env.FLUTTER_CHANNEL }}
           cache: true
           pub-cache: true
-          cache-key: "deeplinkx-pages-flutter-:os:-:channel:-:version:-:arch:-:hash:"
-          pub-cache-key: "deeplinkx-pages-flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
+          cache-key: "deeplinkx-flutter-:os:-:channel:-:version:-:arch:-:hash:"
+          pub-cache-key: "deeplinkx-example-pub-:os:-:channel:-:version:-:arch:-:hash:"
 
       - name: Flutter version
         run: flutter --version
-
-      - name: Enable web
-        run: flutter config --enable-web
-
-      - name: Pub get (root)
-        run: flutter pub get
 
       - name: Pub get (example)
         working-directory: example
@@ -70,17 +64,21 @@ jobs:
           cp -v build/web/index.html build/web/404.html
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: example/build/web
 
   deploy:
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: build
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/pub-readiness.yml
+++ b/.github/workflows/pub-readiness.yml
@@ -21,19 +21,22 @@ env:
 jobs:
   pub-readiness:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Set up Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: ${{ env.FLUTTER_CHANNEL }}
           cache: true
           pub-cache: true
-          cache-key: "deeplinkx-pub-readiness-flutter-:os:-:channel:-:version:-:arch:-:hash:"
-          pub-cache-key: "deeplinkx-pub-readiness-flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
+          cache-key: "deeplinkx-flutter-:os:-:channel:-:version:-:arch:-:hash:"
+          pub-cache-key: "deeplinkx-pub-:os:-:channel:-:version:-:arch:-:hash:"
 
       - name: Flutter version
         run: flutter --version
@@ -42,9 +45,13 @@ jobs:
         run: flutter pub get
 
       - name: Install WebP tools
-        run: sudo apt-get install -y webp
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y webp
 
       - name: Activate Pana
+        # Intentionally unpinned so CI scoring tracks the live pana version
+        # used by pub.dev.
         run: dart pub global activate pana
 
       - name: Check Pana score

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,27 +14,13 @@ concurrency:
 
 jobs:
   verify-tag-on-master:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Verify tag commit is on master
-        run: |
-          git fetch origin master
-          tag_commit="$(git rev-parse "${GITHUB_REF}^{commit}")"
-          if ! git merge-base --is-ancestor "$tag_commit" origin/master; then
-            echo "Tag commit $tag_commit is not contained in origin/master." >&2
-            exit 1
-          fi
+    uses: ./.github/workflows/verify-tag.yml
 
   publish:
     needs: verify-tag-on-master
     permissions:
       contents: read
       id-token: write
-    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
     with:
       environment: pub.dev

--- a/.github/workflows/release-demo-apks.yml
+++ b/.github/workflows/release-demo-apks.yml
@@ -18,31 +18,20 @@ env:
 
 jobs:
   verify-tag-on-master:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Verify tag commit is on master
-        run: |
-          git fetch origin master
-          tag_commit="$(git rev-parse "${GITHUB_REF}^{commit}")"
-          if ! git merge-base --is-ancestor "$tag_commit" origin/master; then
-            echo "Tag commit $tag_commit is not contained in origin/master." >&2
-            exit 1
-          fi
+    uses: ./.github/workflows/verify-tag.yml
 
   build:
     needs: verify-tag-on-master
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: temurin
           java-version: '17'
@@ -53,20 +42,17 @@ jobs:
             example/pubspec.lock
 
       - name: Set up Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           channel: ${{ env.FLUTTER_CHANNEL }}
           cache: true
           pub-cache: true
-          cache-key: "deeplinkx-demo-apks-flutter-:os:-:channel:-:version:-:arch:-:hash:"
-          pub-cache-key: "deeplinkx-demo-apks-flutter-pub-:os:-:channel:-:version:-:arch:-:hash:"
+          cache-key: "deeplinkx-flutter-:os:-:channel:-:version:-:arch:-:hash:"
+          pub-cache-key: "deeplinkx-example-pub-:os:-:channel:-:version:-:arch:-:hash:"
 
       - name: Flutter version
         run: flutter --version
-
-      - name: Pub get (root)
-        run: flutter pub get
 
       - name: Pub get (example)
         working-directory: example
@@ -136,7 +122,7 @@ jobs:
           done
 
       - name: Upload APK artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: demo-apks-${{ github.ref_name }}
           path: ${{ runner.temp }}/demo-apks/*.apk
@@ -146,11 +132,12 @@ jobs:
   publish-release:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
     steps:
       - name: Download APK artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: demo-apks-${{ github.ref_name }}
           path: ${{ runner.temp }}/demo-apks

--- a/.github/workflows/verify-tag.yml
+++ b/.github/workflows/verify-tag.yml
@@ -1,0 +1,28 @@
+name: Verify Tag on Master
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # Full history so tag-ancestry can be checked reliably (shallow
+          # clones can misreport merge-base results).
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify tag commit is on master
+        run: |
+          tag_commit="$(git rev-parse "${GITHUB_REF}^{commit}")"
+          if ! git merge-base --is-ancestor "$tag_commit" origin/master; then
+            echo "Tag commit $tag_commit is not contained in origin/master." >&2
+            exit 1
+          fi


### PR DESCRIPTION
Audit of all 5 workflows for security, performance, and logic issues.

## Security
- **Pin every action to a commit SHA** (upgraded to latest releases, all majors verified drop-in — they are Node 24 runtime bumps): checkout v6.0.3, setup-java v5.6.0, upload-artifact v7.0.1, download-artifact v8.0.1, upload-pages-artifact v5.0.0, deploy-pages v5.0.0, flutter-action v2.23.0, coveralls v2.3.6, dart-lang/setup-dart publish v1.7.2. Mutable tags could be hijacked to run arbitrary code with access to signing keys / pub.dev OIDC / Pages deploy.
- **Add Dependabot** for the github-actions ecosystem (weekly, minor/patch grouped) so pins don't rot.
- **Scope Pages permissions**: `pages: write` + `id-token: write` move from workflow level to the deploy job only — the build job no longer holds deploy credentials.
- **Coveralls job token reduced to `contents: read`** — the token is transmitted to coveralls.io; the action only uploads (PR status comes from the Coveralls GitHub App). If the Coveralls PR status disappears, restore the two write scopes.
- **`persist-credentials: false`** on all checkouts (no job uses git credentials afterwards; `gh` uses `GH_TOKEN`).

## Performance
- **`timeout-minutes` on every job** (previously a hung job could burn the 360-min default).
- **Unified cache-key prefixes**: tag-triggered release runs can only read default-branch caches, so the 4 distinct per-workflow prefixes meant every release build was fully cold and the same Flutter SDK was cached 4× against the 10 GB quota. Now: one shared SDK cache, one root-deps pub cache (CI), one example-deps pub cache (Pages + APK release).
- Dropped redundant root `flutter pub get` where only `example/` is built; docs-only changes skip test/coverage CI (safe: no required-status-check ruleset on master).

## Logic
- **Extracted duplicated `verify-tag-on-master`** into a reusable `verify-tag.yml` (`workflow_call`) used by both release pipelines; dropped its redundant `git fetch` after `fetch-depth: 0`.
- **Pages deploys no longer cancelled mid-flight** (`cancel-in-progress: false`, per the GitHub starter workflow).
- Removed dead `packages/**` path filter and obsolete `flutter config --enable-web`; `apt-get update` before installing webp; pana left intentionally unpinned (documented) to mirror pub.dev's live scoring.

Validated with actionlint 1.7.12 (zero findings). Tag-triggered paths (publish + APK release) get exercised on the next release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)