### PR TITLE
fix(maps): use canonical Google Maps fallback URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.4.4
+
+### Fixed
+
+* Updated Google Maps view and search web fallbacks to the canonical Maps URL formats with the required `api=1` parameter.
+* Documented and regression-tested destination-only and explicit-origin coordinate directions fallbacks, which already used the canonical `api=1` contract.
+
 ## 1.4.3
 
 ### Added

--- a/doc/apps/google_maps.md
+++ b/doc/apps/google_maps.md
@@ -6,6 +6,7 @@ DeeplinkX provides support for Google Maps deep linking actions on iOS and Andro
 
 - [Android Intents](https://developer.android.com/guide/components/google-maps-intents)
 - [iOS URL Scheme](https://developers.google.com/maps/documentation/urls/ios-urlscheme)
+- [Google Maps URLs](https://developers.google.com/maps/documentation/urls/get-started)
 
 ## Available Actions
 
@@ -83,10 +84,13 @@ Add the following to your `android/app/src/main/AndroidManifest.xml` inside the 
 - Directions with coordinates: `https://www.google.com/maps/dir/?api=1&destination={dest_lat},{dest_lng}&origin={origin_lat},{origin_lng}&travelmode={mode}`
 
 ### Web Fallback URLs
-- View map: `https://www.google.com/maps/@{lat},{lng},{zoom}z`
-- Search: `https://www.google.com/maps/@?api=1&query={query}`
-- Directions: `https://maps.google.com/maps/dir/?destination={destination}&origin={origin}&travelmode={mode}`
-- Directions with coordinates: `https://maps.google.com/maps/dir/?origin={origin_lat},{origin_lng}&destination={dest_lat},{dest_lng}&travelmode={mode}`
+- View map: `https://www.google.com/maps/@?api=1&map_action=map&center={lat},{lng}&zoom={zoom}`
+- Search: `https://www.google.com/maps/search/?api=1&query={query}`
+- Directions: `https://www.google.com/maps/dir/?api=1&destination={destination}&origin={origin}&travelmode={mode}`
+- Directions with coordinates: `https://www.google.com/maps/dir/?api=1&destination={dest_lat},{dest_lng}&origin={origin_lat},{origin_lng}&travelmode={mode}`
+- Directions from current location: `https://www.google.com/maps/dir/?api=1&destination=40.6892,-74.0445`
+
+Google requires `api=1` on Maps URLs. Without it, the documented action parameters can be ignored. Coordinate destinations use latitude,longitude order; when `origin` is omitted, Google Maps starts from the user's current location.
 
 ## Supported Fallback Stores
 When the Google Maps app is not installed, DeeplinkX can redirect users to download Google Maps from:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -71,7 +71,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.4.3"
+    version: "1.4.4"
   deeplink_x_android:
     dependency: transitive
     description:

--- a/lib/src/apps/downloadable_apps/google_maps.dart
+++ b/lib/src/apps/downloadable_apps/google_maps.dart
@@ -204,7 +204,7 @@ class GoogleMapsSearchAction extends GoogleMaps
   Uri get fallbackLink => Uri(
         scheme: 'https',
         host: 'www.google.com',
-        path: 'maps/@',
+        path: 'maps/search/',
         queryParameters: {
           'api': '1',
           'query': query,
@@ -256,7 +256,13 @@ class GoogleMapsViewAction extends GoogleMaps
   Uri get fallbackLink => Uri(
         scheme: 'https',
         host: 'www.google.com',
-        path: 'maps/@${coordinate.latitude},${coordinate.longitude},${zoom ?? 14}z',
+        path: 'maps/@',
+        queryParameters: {
+          'api': '1',
+          'map_action': 'map',
+          'center': coordinate.toString(),
+          'zoom': (zoom ?? 14).toString(),
+        },
       );
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: deeplink_x
 description: Type-safe Flutter deeplinks for WhatsApp, Telegram, Instagram, YouTube, Google Maps, Waze and app stores, with automatic store and web fallback.
-version: 1.4.3
+version: 1.4.4
 homepage: https://github.com/DeepLinkX/DeeplinkX
 repository: https://github.com/DeepLinkX/DeeplinkX
 issue_tracker: https://github.com/DeepLinkX/DeeplinkX/issues

--- a/test/src/apps/google_maps_test.dart
+++ b/test/src/apps/google_maps_test.dart
@@ -55,7 +55,7 @@ void main() {
       );
       expect(
         action.fallbackLink.toString(),
-        'https://www.google.com/maps/@?api=1&query=1600+Amphitheatre+Parkway',
+        'https://www.google.com/maps/search/?api=1&query=1600+Amphitheatre+Parkway',
       );
       expect(
         action.androidIntentOptions.data,
@@ -95,7 +95,20 @@ void main() {
       expect(double.parse(action.appLink.queryParameters['zoom']!), 15);
 
       expect(action.fallbackLink.host, 'www.google.com');
-      expect(action.fallbackLink.path, '/maps/@37.422,-122.084,15.0z');
+      expect(action.fallbackLink.path, '/maps/@');
+      expect(
+        action.fallbackLink.queryParameters,
+        {
+          'api': '1',
+          'map_action': 'map',
+          'center': '37.422,-122.084',
+          'zoom': '15.0',
+        },
+      );
+      expect(
+        action.fallbackLink.toString(),
+        'https://www.google.com/maps/@?api=1&map_action=map&center=37.422%2C-122.084&zoom=15.0',
+      );
 
       final intentUri = Uri.parse(action.androidIntentOptions.data!);
       expect(intentUri.scheme, 'geo');
@@ -119,11 +132,13 @@ void main() {
       expect(intentUri.scheme, 'https');
       expect(intentUri.host, 'www.google.com');
       expect(intentUri.path, '/maps/dir/');
+      expect(intentUri.queryParameters['api'], '1');
       expect(intentUri.queryParameters['destination'], 'Statue of Liberty');
       expect(intentUri.queryParameters['origin'], 'Times Square, New York');
       expect(intentUri.queryParameters['travelmode'], 'transit');
 
       expect(action.fallbackLink.path, '/maps/dir/');
+      expect(action.fallbackLink.queryParameters['api'], '1');
       expect(action.fallbackLink.queryParameters['travelmode'], 'transit');
       expect(action.fallbackLink.queryParameters['destination'], 'Statue of Liberty');
       expect(action.fallbackLink.queryParameters['origin'], 'Times Square, New York');
@@ -145,14 +160,35 @@ void main() {
       expect(intentUri.scheme, 'https');
       expect(intentUri.host, 'www.google.com');
       expect(intentUri.path, '/maps/dir/');
+      expect(intentUri.queryParameters['api'], '1');
       expect(intentUri.queryParameters['destination'], '40.6892,-74.0445');
       expect(intentUri.queryParameters['origin'], '40.758,-73.9855');
       expect(intentUri.queryParameters['travelmode'], 'walking');
 
       expect(action.fallbackLink.path, '/maps/dir/');
+      expect(action.fallbackLink.queryParameters['api'], '1');
       expect(action.fallbackLink.queryParameters['travelmode'], 'walking');
       expect(action.fallbackLink.queryParameters['destination'], '40.6892,-74.0445');
       expect(action.fallbackLink.queryParameters['origin'], '40.758,-73.9855');
+      expect(
+        action.fallbackLink.toString(),
+        'https://www.google.com/maps/dir/?api=1&destination=40.6892%2C-74.0445&origin=40.758%2C-73.9855&travelmode=walking',
+      );
+    });
+
+    test('coordinate directions preserve current location with a canonical fallback', () {
+      final action = GoogleMaps.directionsWithCoords(
+        destination: const Coordinate(latitude: 40.6892, longitude: -74.0445),
+      );
+
+      expect(
+        action.fallbackLink.toString(),
+        'https://www.google.com/maps/dir/?api=1&destination=40.6892%2C-74.0445',
+      );
+      expect(action.fallbackLink.queryParameters['api'], '1');
+      expect(action.fallbackLink.queryParameters['destination'], '40.6892,-74.0445');
+      expect(action.fallbackLink.queryParameters.containsKey('origin'), isFalse);
+      expect(action.fallbackLink.queryParameters.containsKey('travelmode'), isFalse);
     });
   });
 }


### PR DESCRIPTION
## Summary

- replace Google Maps view fallbacks with the canonical `maps/@?api=1&map_action=map` URL
- replace Google Maps search fallbacks with the canonical `maps/search/?api=1` URL
- retain the existing canonical directions implementation and add exact regression coverage for destination-only and explicit-origin coordinate routes
- correct the Google Maps documentation so every action-preserving web URL includes the required `api=1` parameter

## Root Cause

The view fallback still used the legacy path-encoded center format, search used the map endpoint instead of the search endpoint, and the documentation showed stale directions URLs without `api=1`. Google documents that action parameters are ignored when `api=1` is absent.

## Release

- rebased onto master after PR #43 (NAVER Map) merged as `1.4.3`
- bumps the package to `1.4.4`
- adds a top `Fixed` changelog entry without modifying earlier releases
- updates only the local `deeplink_x` version in `example/pubspec.lock`

## Verification

- `fvm dart format .`
- `fvm flutter analyze` (root): passed
- focused Google Maps tests: 10 passed
- `fvm flutter test` (root): passed
- `fvm flutter test` (example): 23 passed

## Reference

- [Official Google Maps URLs documentation](https://developers.google.com/maps/documentation/urls/get-started)